### PR TITLE
Fixate node version to 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ rvm:
   - 2.4
   - 2.3
   - ruby-head
-node_js:
-  - "iojs"
-  - "8"
 before_install: 
+  - nvm install 8
   - gem install bundler -v 1.16.1
   - npm install -g puppeteer
   - npm install


### PR DESCRIPTION
 - Based on https://travis-ci.community/t/cannot-specify-node-js-version-for-ruby-project-on-osx/2952 suggestion