### PR TITLE
Add configurable log setting for metanorma

### DIFF
--- a/lib/metanorma.rb
+++ b/lib/metanorma.rb
@@ -1,5 +1,7 @@
 require "metanorma/version"
 require "asciidoctor"
+require "metanorma/util"
+require "metanorma/config"
 require "metanorma/input"
 require "metanorma/output"
 require "metanorma/registry"

--- a/lib/metanorma/compile.rb
+++ b/lib/metanorma/compile.rb
@@ -47,23 +47,23 @@ module Metanorma
 
     def validate_type(options)
       unless options[:type]
-        puts "[metanorma] Error: Please specify a standard type: #{@registry.supported_backends}."
+        Util.log("[metanorma] Error: Please specify a standard type: #{@registry.supported_backends}.", :error)
         return nil
       end
       stdtype = options[:type].to_sym
       unless @registry.supported_backends.include? stdtype
-        puts "[metanorma] Warning: #{stdtype} is not a default standard type."
-        puts "[metanorma] Info: Attempting to load `metanorma-#{stdtype}` gem for standard type `#{stdtype}`."
+        Util.log("[metanorma] Warning: #{stdtype} is not a default standard type.", :warning)
+        Util.log("metanorma] Info: Attempting to load `metanorma-#{stdtype}` gem for standard type `#{stdtype}`.", :info)
       end
       begin
         require "metanorma-#{stdtype}"
-        puts "[metanorma] Info: gem `metanorma-#{stdtype}` loaded."
+        Util.log("[metanorma] Info: gem `metanorma-#{stdtype}` loaded.", :info)
       rescue LoadError
-        puts "[metanorma] Error: loading gem `metanorma-#{stdtype}` failed. Exiting."
+        Util.log("[metanorma] Error: loading gem `metanorma-#{stdtype}` failed. Exiting.", :error)
         return false
       end
       unless @registry.supported_backends.include? stdtype
-        puts "[metanorma] Error: The `metanorma-#{stdtype}` gem still doesn't support `#{stdtype}`. Exiting."
+        Util.log("[metanorma] Error: The `metanorma-#{stdtype}` gem still doesn't support `#{stdtype}`. Exiting.", :error)
         return false
       end
       true
@@ -71,7 +71,7 @@ module Metanorma
 
     def validate_format(options)
       unless options[:format] == :asciidoc
-        puts "[metanorma] Error: Only source file format currently supported is 'asciidoc'."
+        Util.log("[metanorma] Error: Only source file format currently supported is 'asciidoc'.", :error)
         return false
       end
       true
@@ -83,7 +83,7 @@ module Metanorma
       end
       extensions = options[:extension_keys].inject([]) do |memo, e|
         @processor.output_formats[e] and memo << e or
-          puts "[metanorma] Error: #{e} format is not supported for this standard."
+          Util.log("[metanorma] Error: #{e} format is not supported for this standard.", :error)
         memo
       end
       extensions
@@ -92,7 +92,7 @@ module Metanorma
     def process_input(filename, options)
       case extname = File.extname(filename)
       when ".adoc"
-        puts "[metanorma] Processing: Asciidoctor input."
+        Util.log("[metanorma] Processing: Asciidoctor input.", :info)
         file = File.read(filename, encoding: "utf-8")
         options[:asciimath] and
           file.sub!(/^(=[^\n]+\n)/, "\\1:mn-keep-asciimath:\n")
@@ -101,12 +101,12 @@ module Metanorma
           file.gsub!(/^include::/, "include::#{dir}/")
         [file, @processor.input_to_isodoc(file, filename)]
       when ".xml"
-        puts "[metanorma] Processing: Metanorma XML input."
+        Util.log("[metanorma] Processing: Metanorma XML input.", :info)
         # TODO NN: this is a hack -- we should provide/bridge the
         # document attributes in Metanorma XML
         ["", File.read(filename, encoding: "utf-8")]
       else
-        puts "[metanorma] Error: file extension #{extname} is not supported."
+        Util.log("[metanorma] Error: file extension #{extname} is not supported.", :error)
         nil
       end
     end

--- a/lib/metanorma/config.rb
+++ b/lib/metanorma/config.rb
@@ -1,0 +1,23 @@
+module Metanorma
+  module Config
+    def configure
+      if block_given?
+        yield configuration
+      end
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  class Configuration
+    attr_accessor :logs
+
+    def initialize
+      @logs ||= [:warning, :error]
+    end
+  end
+
+  extend Config
+end

--- a/lib/metanorma/registry.rb
+++ b/lib/metanorma/registry.rb
@@ -19,7 +19,7 @@ module Metanorma
     def register processor
       raise Error unless processor < ::Metanorma::Processor
       p = processor.new
-      puts "[metanorma] processor \"#{p.short}\" registered"
+      Util.log("[metanorma] processor \"#{p.short}\" registered", :info)
       @processors[p.short] = p
     end
 

--- a/lib/metanorma/util.rb
+++ b/lib/metanorma/util.rb
@@ -1,0 +1,11 @@
+module Metanorma
+  module Util
+    def self.log(message, type = :info)
+      log_types = Metanorma.configuration.logs.map(&:to_s) || []
+
+      if log_types.include?(type.to_s)
+        puts(message)
+      end
+    end
+  end
+end

--- a/spec/metanorma/config_spec.rb
+++ b/spec/metanorma/config_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Config do
+  before { restore_to_default_config }
+  after { restore_to_default_config }
+
+  describe ".configure" do
+    it "allows us to set our configuration" do
+      logs_types = ["warning", :error]
+
+      Metanorma.configuration.logs = logs_types
+
+      expect(Metanorma.configuration.logs).to eq(logs_types)
+    end
+  end
+
+  def restore_to_default_config
+    Metanorma.configuration.logs = [:warning, :error]
+  end
+end


### PR DESCRIPTION
Currently, the `metanorma` gem is logging every single details whenever someone runs metanorma / dependent gems. This is very helpful for development, but it might overwhelm a normal user

So, this commit wrap this around a configuration, by default it will only show `warning` and `error` to the user, but if we want then we can configure this using `logs` configuration

We can set this configuration by adding an initializer or add the following lines to any of our ruby file.

```sh
Metanorma.configuration.logs = [:warning, :error]
```

Related: https://github.com/metanorma/metanorma-cli/issues/27