### PR TITLE
Headless puppeteer reduce required libraries (X-Server related)

### DIFF
--- a/bin/metanorma-pdf.js
+++ b/bin/metanorma-pdf.js
@@ -7,7 +7,7 @@ const createPdf = async() => {
   let browser;
   let exitCode = 0;
   try {
-    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
+    browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox', '--headless']});
     const page = await browser.newPage();
     await page.goto(process.argv[2], {waitUntil: 'networkidle2'});
     await page.pdf({


### PR DESCRIPTION
During https://github.com/metanorma/metanorma/issues/63 & https://github.com/metanorma/metanorma-nist/issues/136 I have found that we have problems running metanorma on Linux distribution without X Server

Full list of required libraries is huge: `libx11-6, libx11-xcb1, libxcomposite1, libxcursor1, libxdamage1, libxext6, libxfixes3, libxi6, libxrandr2, libxrender1, libxss1, libxtst6, libnss3, libcups2, libatk1.0-0, libatk-bridge2.0-0, libgdk-pixbuf2.0-0, libglib2.0-0, libgtk-3-0, libasound2`

By passing `--headless` we don't need most of them anymore https://medium.com/@ali.dev/how-to-setup-chrome-headless-on-gitlab-ci-with-puppeteer-docker-fbb562cbaee1