### PR TITLE
Metanorma should no longer require `:type` option when given file is Metanorma XML (WIP)

### DIFF
--- a/lib/metanorma/compile.rb
+++ b/lib/metanorma/compile.rb
@@ -28,8 +28,19 @@ module Metanorma
       end
     end
 
+    def xml_options_extract(file)
+      xml = Nokogiri::XML(file)
+      if xml.root
+        @registry.root_tags.each do |k, v|
+          return { type: k }  if v == xml.root.name
+        end
+      end
+      {}
+    end
+
     def options_extract(filename, options)
       o = Metanorma::Input::Asciidoc.new.extract_metanorma_options(File.read(filename, encoding: "utf-8"))
+      o = o.merge(xml_options_extract(File.read(filename, encoding: "utf-8")))
       options[:type] ||= o[:type]&.to_sym
       dir = filename.sub(%r(/[^/]+$), "/")
       options[:relaton] ||= "#{dir}/#{o[:relaton]}" if o[:relaton]

--- a/lib/metanorma/input/asciidoc.rb
+++ b/lib/metanorma/input/asciidoc.rb
@@ -1,3 +1,5 @@
+require "nokogiri"
+
 module Metanorma
   module Input
 

--- a/lib/metanorma/processor.rb
+++ b/lib/metanorma/processor.rb
@@ -6,6 +6,7 @@ module Metanorma
 
     attr_reader :short
     attr_reader :input_format
+    attr_reader :asciidoctor_backend
 
     def initialize
       raise "This is an abstract class!"

--- a/lib/metanorma/registry.rb
+++ b/lib/metanorma/registry.rb
@@ -44,5 +44,14 @@ module Metanorma
       end
     end
 
+    def root_tags
+      @processors.inject({}) do |acc, (k,v)|
+        if v.asciidoctor_backend
+          x = Asciidoctor.load nil, {backend: v.asciidoctor_backend}
+          acc[k] = x.converter.class::XML_ROOT_TAG
+        end
+        acc
+      end
+    end
   end
 end

--- a/metanorma.gemspec
+++ b/metanorma.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'asciidoctor'
   spec.add_runtime_dependency 'htmlentities'
+  spec.add_runtime_dependency 'nokogiri'
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe Metanorma::Compile do
     expect(xml).to include "</iso-standard>"
   end
 
+  it "processes a Metanorma XML ISO document" do
+    FileUtils.rm_f %w(spec/assets/test.xml spec/assets/test.html spec/assets/test.alt.html spec/assets/test.doc)
+    Metanorma::Compile.new().compile("spec/assets/test.adoc", { type: "iso" } )
+    expect(File.exist?("spec/assets/test.xml")).to be true
+    FileUtils.rm_f %w(spec/assets/test.html spec/assets/test.alt.html spec/assets/test.doc)
+    expect { Metanorma::Compile.new().compile("spec/assets/test.xml") }.not_to output(/Error: Please specify a standard type/).to_stdout
+    expect(File.exist?("spec/assets/test.html")).to be true
+    html = File.read("spec/assets/test.html", encoding: "utf-8")
+    expect(html).to include "ISO copyright office"
+  end
+
   it "extracts isodoc options from asciidoc file" do
     FileUtils.rm_f %w(spec/assets/test.xml spec/assets/test.html spec/assets/test.alt.html spec/assets/test.doc)
     Metanorma::Compile.new().compile("spec/assets/test.adoc", { type: "iso", extension_keys: [:html] } )

--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -48,4 +48,22 @@ RSpec.describe Metanorma::Registry do
     registry = Metanorma::Registry.instance
     expect{registry.register(Metanorma)}.to raise_error(Error) 
   end
+
+  it "detects root tag of iso" do
+    class NewProcessor < Metanorma::Processor
+      def initialize
+        @short = :iso
+        @asciidoctor_backend = :iso
+      end
+
+      def output_formats
+        { xyz: "xyz" }
+      end
+
+    end
+    require "metanorma-iso"
+    registry = Metanorma::Registry.instance
+    registry.register(NewProcessor)
+    expect(registry.root_tags[:iso]).to eq "iso-standard"
+  end
 end


### PR DESCRIPTION
See ticket https://github.com/metanorma/metanorma/issues/91  for what this is about.