### PR TITLE
Dynamically detect type for Metanorma document

### DIFF
--- a/metanorma.gemspec
+++ b/metanorma.gemspec
@@ -21,10 +21,11 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   #spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency 'asciidoctor'
-  spec.add_runtime_dependency 'htmlentities'
+  spec.add_runtime_dependency "asciidoctor"
+  spec.add_runtime_dependency "htmlentities"
+  spec.add_runtime_dependency "nokogiri"
 
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe Metanorma::Compile do
     expect(xml).to include "</iso-standard>"
   end
 
+  it "processes a Metanorma XML ISO document" do
+    FileUtils.rm_f %w(spec/assets/test.xml spec/assets/test.html spec/assets/test.alt.html spec/assets/test.doc)
+    Metanorma::Compile.new().compile("spec/assets/test.adoc", { type: "iso" } )
+    expect(File.exist?("spec/assets/test.xml")).to be true
+
+    FileUtils.rm_f %w(spec/assets/test.html spec/assets/test.alt.html spec/assets/test.doc)
+    expect { Metanorma::Compile.new().compile("spec/assets/test.xml") }.not_to output(/Error: Please specify a standard type/).to_stdout
+    expect(File.exist?("spec/assets/test.html")).to be true
+    html = File.read("spec/assets/test.html", encoding: "utf-8")
+    expect(html).to include "ISO copyright office"
+  end
+
   it "extracts isodoc options from asciidoc file" do
     FileUtils.rm_f %w(spec/assets/test.xml spec/assets/test.html spec/assets/test.alt.html spec/assets/test.doc)
     Metanorma::Compile.new().compile("spec/assets/test.adoc", { type: "iso", extension_keys: [:html] } )


### PR DESCRIPTION
This commit adds some dynamic type detection for Metanorma document, but to keep consistency with the old version it stills give preference to type options. If user provided a `type` as an option then it will
use that one directly, but if there are no type provided then it will try to extract the type from the XML document and use that one.

Another important thing, since we've a validation running afterword so invalid type would be caught by that and everything else should work as expected.

Closes #91 