### PR TITLE
metanorma/metanorma-standoc#207 fix handling docs with CRLF line endings

### DIFF
--- a/lib/metanorma/compile.rb
+++ b/lib/metanorma/compile.rb
@@ -39,8 +39,9 @@ module Metanorma
     end
 
     def options_extract(filename, options)
-      o = Metanorma::Input::Asciidoc.new.extract_metanorma_options(File.read(filename, encoding: "utf-8"))
-      o = o.merge(xml_options_extract(File.read(filename, encoding: "utf-8")))
+      content = read_file(filename)
+      o = Metanorma::Input::Asciidoc.new.extract_metanorma_options(content)
+      o = o.merge(xml_options_extract(content))
       options[:type] ||= o[:type]&.to_sym
       dir = filename.sub(%r(/[^/]+$), "/")
       options[:relaton] ||= "#{dir}/#{o[:relaton]}" if o[:relaton]
@@ -103,7 +104,7 @@ module Metanorma
       case extname = File.extname(filename)
       when ".adoc"
         Util.log("[metanorma] Processing: Asciidoctor input.", :info)
-        file = File.read(filename, encoding: "utf-8")
+        file = read_file(filename)
         options[:asciimath] and
           file.sub!(/^(=[^\n]+\n)/, "\\1:mn-keep-asciimath:\n")
         dir = File.dirname(filename)
@@ -114,11 +115,15 @@ module Metanorma
         Util.log("[metanorma] Processing: Metanorma XML input.", :info)
         # TODO NN: this is a hack -- we should provide/bridge the
         # document attributes in Metanorma XML
-        ["", File.read(filename, encoding: "utf-8")]
+        ["", read_file(filename)]
       else
         Util.log("[metanorma] Error: file extension #{extname} is not supported.", :error)
         nil
       end
+    end
+
+    def read_file(filename)
+      File.read(filename, encoding: "utf-8").gsub("\r\n", "\n")
     end
 
     def relaton_export(isodoc, options)

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -167,5 +167,26 @@ end
     expect(xml).to include "ABC"
   end
 
+  it "processes a Metanorma XML ISO document with CRLF line endings" do
+    doc_name = 'test_crlf'
+    FileUtils.rm_f Dir["spec/assets/#{doc_name}.*"]
 
+    # convert LF -> CRLF
+    doc = "spec/assets/#{doc_name}.adoc"
+    line_no = 0
+    eol = Gem.win_platform? ? "\n" : "\r\n"
+    File.open(doc, "w:UTF-8") do |output|
+      File.readlines("spec/assets/test.adoc", chomp: true).each do |line|
+        if line_no == 3
+          output.write(":mn-document-class: iso#{eol}")
+          output.write(":mn-output-extensions: xml,html,doc,rxl#{eol}")
+        end
+        output.write("#{line}#{eol}")
+        line_no += 1
+      end
+    end
+
+    Metanorma::Compile.new.compile(doc)
+    expect(File.exist?("spec/assets/#{doc_name}.xml")).to be true
+  end
 end


### PR DESCRIPTION
 - metanorma/metanorma-standoc#207