### PR TITLE
Be more specific about gem loading errors

### DIFF
--- a/lib/metanorma/compile.rb
+++ b/lib/metanorma/compile.rb
@@ -63,21 +63,32 @@ module Metanorma
         Util.log("[metanorma] Error: Please specify a standard type: #{@registry.supported_backends}.", :error)
         return nil
       end
+
       stdtype = options[:type].to_sym
+      metanorma_flavor = "metanorma-#{stdtype}"
+
       unless @registry.supported_backends.include? stdtype
-        Util.log("[metanorma] Info: Loading `metanorma-#{stdtype}` gem for standard type `#{stdtype}`.", :info)
+        Util.log("[metanorma] Info: Loading `#{metanorma_flavor}` gem for standard type `#{stdtype}`.", :info)
       end
+
       begin
         require "metanorma-#{stdtype}"
-        Util.log("[metanorma] Info: gem `metanorma-#{stdtype}` loaded.", :info)
+        Util.log("[metanorma] Info: gem `#{metanorma_flavor}` loaded.", :info)
+
+      rescue Gem::ConflictError
+        Util.log("[metanorma] Error: Couldn't resolve dependencies for `metanorma-#{stdtype}`, Please add it to your Gemfile and run bundle install first", :error)
+        return false
+
       rescue LoadError
-        Util.log("[metanorma] Error: loading gem `metanorma-#{stdtype}` failed. Exiting.", :error)
+        Util.log("[metanorma] Error: loading gem `#{metanorma_flavor}` failed. Exiting.", :error)
         return false
       end
+
       unless @registry.supported_backends.include? stdtype
-        Util.log("[metanorma] Error: The `metanorma-#{stdtype}` gem still doesn't support `#{stdtype}`. Exiting.", :error)
+        Util.log("[metanorma] Error: The `#{metanorma_flavor}` gem still doesn't support `#{stdtype}`. Exiting.", :error)
         return false
       end
+
       true
     end
 


### PR DESCRIPTION
Currently, the gem is only taking care of the higher level `LoadError`, this is all good when the gem is not present in user's system. But this could be little bit confusing when the gem is present in user's system but couldn't be activated because of dependency confliction.

This commit adds another rescue block to handle gem conflicts, so now it will also check gem compatibilities and if the loading error is because of the Gem confliction then it will report that appropriately

Related: https://github.com/metanorma/metanorma-ribose/issues/83