### PR TITLE
Handle UnsupportedFontError & MissingFontError

### DIFF
--- a/lib/metanorma/compile.rb
+++ b/lib/metanorma/compile.rb
@@ -297,9 +297,8 @@ module Metanorma
         Util.log("[fontist] Aborting without proper fonts installed," \
           " make sure that you have set option --agree-to-terms", :fatal)
       end
-    rescue Fontist::Errors::MissingFontError => e
-      font = /Font '([^']+)'/.match(e.to_s)[1]
-      Util.log("[fontist] '#{font}' font is not supported. " \
+    rescue Fontist::Errors::FontError => e
+      Util.log("[fontist] '#{e.font}' font is not supported. " \
         "Please report this issue at github.com/metanorma/metanorma-#{@processor.short}/issues" \
         " to report this issue.", :info)
     rescue Fontist::Errors::FormulaIndexNotFoundError


### PR DESCRIPTION
Related:
 - https://github.com/fontist/fontist/pull/206

Blocks:
 - https://github.com/metanorma/ACVP/pull/2

@ronaldtse once it approved I think we need to release `metanorma` gem