### PR TITLE
metanorma/metanorma#215 move font manifest file generation to mn2pdf side

### DIFF
--- a/lib/metanorma/collection_renderer.rb
+++ b/lib/metanorma/collection_renderer.rb
@@ -104,13 +104,15 @@ module Metanorma
 
     class PdfOptionsNode
       def initialize(doctype, options)
-        doc_proc = Metanorma::Registry.instance.find_processor(doctype)
-        @font_locations = FontistUtils.fontist_font_locations(doc_proc, options)
+        docproc = Metanorma::Registry.instance.find_processor(doctype)
+        if FontistUtils.has_fonts_manifest?(docproc, options)
+          @fonts_manifest = FontistUtils.location_manifest(docproc)
+        end
       end
 
       def attr(key)
-        if key == "mn2pdf-font-manifest-file" && @font_locations
-          @font_locations.path
+        if key == "fonts-manifest" && @font_locations
+          @fonts_manifest
         end
       end
     end

--- a/lib/metanorma/compile.rb
+++ b/lib/metanorma/compile.rb
@@ -214,9 +214,11 @@ module Metanorma
         elsif ext == :html && options[:sectionsplit]
           sectionsplit_convert(xml_name, isodoc, outfilename, isodoc_options)
         else
-          if ext == :pdf
-            floc = FontistUtils.fontist_font_locations(@processor, options)
-            isodoc_options[:mn2pdf] = { font_manifest_file: floc.path } if floc
+          if ext == :pdf && FontistUtils.has_fonts_manifest?(@processor,
+                                                             options)
+            isodoc_options[:mn2pdf] = {
+              font_manifest: FontistUtils.location_manifest(@processor),
+            }
           end
           begin
             if @processor.use_presentation_xml(ext)

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe Metanorma::Compile do
 
     allow(Metanorma::FontistUtils).to receive(:fontist_install) {}
     expect(Metanorma::FontistUtils).to receive(:fontist_install).once
-    expect(Metanorma::FontistUtils).to receive(:fontist_font_locations).once
 
     compile.compile("spec/assets/test.adoc", type: "iso", agree_to_terms: true)
   end
@@ -66,7 +65,6 @@ RSpec.describe Metanorma::Compile do
 
     allow(Metanorma::FontistUtils).to receive(:fontist_install) {}
     expect(Metanorma::FontistUtils).to receive(:fontist_install).once
-    expect(Metanorma::FontistUtils).to receive(:fontist_font_locations).once
 
     compile.compile("spec/assets/test.adoc", type: "iso",
                                              agree_to_terms: true,
@@ -217,7 +215,6 @@ RSpec.describe Metanorma::Compile do
 
     expect(Metanorma::FontistUtils).to receive(:fontist_install)
       .with(anything, false, true)
-    expect(Metanorma::FontistUtils).to receive(:fontist_font_locations).once
 
     compile.compile("spec/assets/test.adoc", type: "iso", no_progress: true)
   end


### PR DESCRIPTION
 - metanorma/metanorma#215
 
### Depends on

 - https://github.com/metanorma/isodoc/pull/340
 - https://github.com/metanorma/metanorma-standoc/pull/551
 - https://github.com/metanorma/mn2pdf-ruby/pull/26