### PR TITLE
Let's not re-create the output directory

### DIFF
--- a/lib/metanorma/collection_renderer.rb
+++ b/lib/metanorma/collection_renderer.rb
@@ -47,8 +47,7 @@ module Metanorma
       # list of files in the collection
       @files = read_files folder
       isodoc_populate(@isodoc)
-      FileUtils.rm_rf @outdir
-      FileUtils.mkdir_p @outdir
+      create_non_existing_directory(@outdir)
     end
 
     def dir_name_cleanse(name)
@@ -239,6 +238,12 @@ module Metanorma
     end
 
     private
+
+    def create_non_existing_directory(output_directory)
+      if !File.exist?(output_directory)
+        FileUtils.mkdir_p(output_directory)
+      end
+    end
 
     def format_sort(formats)
       ret = []


### PR DESCRIPTION
Currently, the collection is re-creating the output directory, and it might causes issues like removing all files from the output folder. Normally this is okay, but it become an issue where the user is using the source path as output directory and it deletes all source files.

This commit changes that, and only tries to create a folder when the output folder doesn't already exists.

Related: https://github.com/metanorma/metanorma-cli/pull/286