### PR TITLE
Fix font manifest options fetching

### DIFF
--- a/lib/metanorma/collection_renderer.rb
+++ b/lib/metanorma/collection_renderer.rb
@@ -119,7 +119,7 @@ module Metanorma
       end
 
       def attr(key)
-        if key == "fonts-manifest" && @font_locations
+        if key == "fonts-manifest" && @fonts_manifest
           @fonts_manifest
         end
       end


### PR DESCRIPTION
Currently, in the pdf option class we are setting `fonts_manifest` but when we want to return it then we are checking a non-existing attributes to return that values. That's causing it to return nil, no matter the attribute is set or not.

This commit changes that, so no if we do have the value then it will check and return that accordingly.
