### PR TITLE
Fix a spec which could not remove a dir on Windows

### DIFF
--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe Metanorma::Collection do
           .sub(%r{xlink:href=['"]data:image/gif;base64[^']*'},
                "xlink:href='data:image/gif;base64,_'")
       conact_file_doc_xml = Nokogiri::XML(concat_file)
-      concat_text_doc_xml = Nokogiri::XML(File.open("#{INPATH}/rice-en.final.xml"))
+      concat_text_doc_xml = File.open("#{INPATH}/rice-en.final.xml") do |f|
+        Nokogiri::XML(f)
+      end
 
       %w[
         Dummy_ISO__xa0_17301-1_2016


### PR DESCRIPTION
See
https://github.com/metanorma/metanorma/issues/288
https://github.com/metanorma/metanorma-cli/issues/303
https://github.com/fontist/fontist/pull/327

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
