### PR TITLE
#311 use source-specific fonts in manifest file

### DIFF
--- a/lib/metanorma/collection_render_utils.rb
+++ b/lib/metanorma/collection_render_utils.rb
@@ -110,8 +110,8 @@ module Metanorma
     class PdfOptionsNode
       def initialize(doctype, options)
         docproc = Metanorma::Registry.instance.find_processor(doctype)
-        if FontistUtils.has_fonts_manifest?(docproc, options)
-          @fonts_manifest = FontistUtils.location_manifest(docproc)
+        if FontistUtils.has_custom_fonts?(docproc, options, {})
+          @fonts_manifest = FontistUtils.location_manifest(docproc, options)
         end
       end
 

--- a/lib/metanorma/compile_options.rb
+++ b/lib/metanorma/compile_options.rb
@@ -61,19 +61,6 @@ module Metanorma
     def font_install(opt)
       FontistUtils.install_fonts(@processor, opt) unless @fontist_installed
       @fontist_installed = true
-      !opt[:fonts] ||
-        opt[:fontlicenseagreement] == "continue-without-fonts" and return
-      @font_overrides ||= []
-      font_install_override(opt)
-    end
-
-    def font_install_override(opt)
-      confirm = opt[:fontlicenseagreement] == "no-install-fonts" ? "no" : "yes"
-      CSV.parse_line(opt[:fonts], col_sep: ";").map(&:strip).each do |f|
-        @font_overrides.include?(f) and next
-        Fontist::Font.install(f, confirmation: confirm)
-        @font_overrides << f
-      end
     end
 
     private
@@ -85,9 +72,9 @@ module Metanorma
       %i(bare sectionsplit no_install_fonts baseassetpath aligncrosselements
          tocfigures toctables tocrecommendations strict)
         .each { |x| ret[x] ||= options[x] }
-      ext == :pdf && FontistUtils.has_fonts_manifest?(@processor, options) and
+      ext == :pdf && FontistUtils.has_custom_fonts?(@processor, options, ret) and
         ret[:mn2pdf] =
-          { font_manifest: FontistUtils.location_manifest(@processor) }
+          { font_manifest: FontistUtils.location_manifest(@processor, ret) }
       ret
     end
   end

--- a/lib/metanorma/compile_options.rb
+++ b/lib/metanorma/compile_options.rb
@@ -72,7 +72,8 @@ module Metanorma
       %i(bare sectionsplit no_install_fonts baseassetpath aligncrosselements
          tocfigures toctables tocrecommendations strict)
         .each { |x| ret[x] ||= options[x] }
-      ext == :pdf && FontistUtils.has_custom_fonts?(@processor, options, ret) and
+      custom_fonts = FontistUtils.has_custom_fonts?(@processor, options, ret)
+      ext == :pdf && custom_fonts &&
         ret[:mn2pdf] =
           { font_manifest: FontistUtils.location_manifest(@processor, ret) }
       ret

--- a/lib/metanorma/fontist_utils.rb
+++ b/lib/metanorma/fontist_utils.rb
@@ -109,11 +109,13 @@ module Metanorma
     end
 
     def self.location_manifest(processor, source_attributes)
-      Fontist::Manifest::Locations.from_hash(append_source_fonts(processor.fonts_manifest.dup, source_attributes))
+      Fontist::Manifest::Locations.from_hash(
+        append_source_fonts(processor.fonts_manifest.dup, source_attributes),
+      )
     end
 
     def self.append_source_fonts(manifest, source_attributes)
-      source_attributes[:fonts]&.split(';')&.each { |f| manifest[f] = nil }
+      source_attributes[:fonts]&.split(";")&.each { |f| manifest[f] = nil }
       manifest
     end
   end

--- a/spec/assets/custom_fonts.adoc
+++ b/spec/assets/custom_fonts.adoc
@@ -1,0 +1,11 @@
+= Custom Fonts Document title
+Author
+:docfile: test.adoc
+:nodoc:
+:novalid:
+:no-isobib:
+:fonts: MS Gothic
+
+== Some title
+
+Some text

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -248,6 +248,22 @@ RSpec.describe Metanorma::Compile do
     compile.compile("spec/assets/test.adoc", type: "iso", no_progress: true)
   end
 
+  it "handle :fonts attribute in adoc" do
+    mock_pdf
+    mock_sts
+    compile = Metanorma::Compile.new
+
+    allow(Metanorma::FontistUtils).to receive(:install_fonts_safe)
+      .with(hash_including("MS Gothic"), false, false, false)
+      .and_return(nil)
+
+    allow(Metanorma::FontistUtils).to receive(:location_manifest)
+      .with(anything, anything)
+      .and_return({})
+
+    compile.compile("spec/assets/custom_fonts.adoc", type: "iso")
+  end
+
   it "processes metanorma options inside Asciidoc" do
     Metanorma::Compile.new.compile("spec/assets/test1.adoc",
                                    agree_to_terms: true)


### PR DESCRIPTION
 - #311 
 - #302 (original issue)

### Implementation details

- source-specific fonts (from adoc attributes) passed to manifest yml (mn2pdf)
- `:fontlicenseagreement`attribute support removed, now it's controlled from CLI options