### PR TITLE
Fix memory leak

### DIFF
--- a/lib/metanorma/collection/renderer/utils.rb
+++ b/lib/metanorma/collection/renderer/utils.rb
@@ -12,12 +12,16 @@ module Metanorma
       end
 
       def dup_bibitem(docid, bib)
-        newbib = @files.get(docid, :bibdata).unlink
+        newbib = deep_detached_clone(@files.get(docid, :bibdata))
         newbib.name = "bibitem"
         newbib["hidden"] = "true"
         newbib&.at("./*[local-name() = 'ext']")&.remove
         newbib["id"] = bib["id"]
         newbib
+      end
+
+      def deep_detached_clone(node)
+        Nokogiri::XML(node.to_xml).root
       end
 
       def get_bibitem_docid(bib, identifier)

--- a/lib/metanorma/collection/renderer/utils.rb
+++ b/lib/metanorma/collection/renderer/utils.rb
@@ -12,7 +12,7 @@ module Metanorma
       end
 
       def dup_bibitem(docid, bib)
-        newbib = @files.get(docid, :bibdata).dup
+        newbib = @files.get(docid, :bibdata).unlink
         newbib.name = "bibitem"
         newbib["hidden"] = "true"
         newbib&.at("./*[local-name() = 'ext']")&.remove


### PR DESCRIPTION
This single change fixes a huge memory leak in https://github.com/metanorma/iso-10303/issues/497

https://github.com/metanorma/iso-10303/actions/runs/14406048504 fails (cancels) with out of memory (~10 GB required)
https://github.com/metanorma/iso-10303/actions/runs/14411050709 completes successfully

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
