### PR TITLE
chore: bump minimum Ruby to 3.3

### DIFF
--- a/metanorma.gemspec
+++ b/metanorma.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   # spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.add_runtime_dependency "asciidoctor"
   spec.add_runtime_dependency "concurrent-ruby"


### PR DESCRIPTION
## Summary
Bump `spec.required_ruby_version` from `>= 3.1.0` to `>= 3.3.0` in `metanorma.gemspec`. Ruby 3.1 and 3.2 are both past EOL (3.2 hit EOL 2026-03-31), so bundler should refuse to install against them going forward, matching what the issue asks for.

## Why this matters
Issue metanorma/ci#274 points at Ruby 3.2's EOL. The gemspec was still advertising compatibility with 3.1, which is the older EOL'd branch. Once users on those runtimes install metanorma, they silently run against a security-unsupported Ruby; bundler's job is to fail fast here.

## Changes
- `metanorma.gemspec`: `spec.required_ruby_version = ">= 3.1.0"` → `">= 3.3.0"`.

Verified this is the only Ruby version constraint in the repo:
```
$ grep -rn 'ruby_version\|^ruby' metanorma.gemspec Gemfile Gemfile.devel
metanorma.gemspec:25:  spec.required_ruby_version = ">= 3.3.0"
```

The `3.2.0` hit in `Gemfile` is a commented-out `metanorma-iso` version pin, unrelated to the Ruby runtime. No `.ruby-version` / `.tool-versions` file exists. CI is generated by the shared `metanorma/ci` workflow (`.github/workflows/rake.yml` just delegates to `metanorma/ci/.github/workflows/generic-rake.yml@main`), so the matrix lives upstream and doesn't need touching here.

## Testing
`ruby -c metanorma.gemspec` → `Syntax OK`. Downstream check is on `bundle install`, which will now require Ruby 3.3+ as expected.

Fixes metanorma/ci#274

This contribution was developed with AI assistance (Claude Code).
