### PR TITLE
Util::isodoc_create / load_isodoc: delegate to metanorma-core helpers

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,2 @@
+gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "fix/cleanup-isodoc-create"
+gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"

--- a/lib/metanorma/collection/util/util.rb
+++ b/lib/metanorma/collection/util/util.rb
@@ -156,15 +156,17 @@ module Metanorma
         #           style.gsub(%r{url\(#([^()]+)\)}, "url(#\\1_#{document_suffix})")
         #         end
 
+        # @deprecated Call Metanorma::Core::Isodoc.resolve_converter directly.
         def load_isodoc(flavor, presxml: false)
           Metanorma::Core::Isodoc.resolve_converter(flavor, presxml: presxml)
         end
 
+        # @deprecated Call Metanorma::Core::Isodoc.create directly. Kept as
+        #   a back-compat shim so existing callers keep working unchanged
+        #   while the wrapper is retired.
         def isodoc_create(flavor, lang, script, xml, presxml: false)
-          conv = Metanorma::Core::Isodoc.resolve_converter(flavor,
-                                                           presxml: presxml)
-          Metanorma::Core::Isodoc.init(conv, lang: lang, script: script,
-                                             xml: xml)
+          Metanorma::Core::Isodoc.create(flavor, lang: lang, script: script,
+                                                 xml: xml, presxml: presxml)
         end
 
         def asciidoc_dummy_header

--- a/spec/support/uuid_mock.rb
+++ b/spec/support/uuid_mock.rb
@@ -7,6 +7,7 @@
 
 #require 'debug'; binding.b
 require "metanorma-standoc"
+require "metanorma-core"
 
 module UuidMock
   # Mock UUIDTools::UUID.random_create to return an incrementing counter


### PR DESCRIPTION
`Util::isodoc_create` and `Util::load_isodoc` delegate to `Metanorma::Core::Isodoc.create` and `.resolve_converter` respectively. Marked deprecated so future work can retire them at the call sites in favour of direct `Metanorma::Core::Isodoc` calls.

No behaviour change for existing callers.

Cleanup tagged to https://github.com/metanorma/metanorma/issues/558.

Depends on: metanorma/metanorma-core (PR pending — `fix/cleanup-isodoc-create`)
