### PR TITLE
remove wrong manifest locations call before fonts install

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,8 @@
+# Purpose: pin fontist to the fix branch for issue #465
+# (https://github.com/fontist/fontist/issues/465)
+#
+# Remove this file once a fontist gem containing the fix is released and
+# the regular Gemfile constraint picks it up.
+gem "fontist",
+    git: "https://github.com/fontist/fontist.git",
+    branch: "revert-safe-install"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,8 +1,0 @@
-# Purpose: pin fontist to the fix branch for issue #465
-# (https://github.com/fontist/fontist/issues/465)
-#
-# Remove this file once a fontist gem containing the fix is released and
-# the regular Gemfile constraint picks it up.
-gem "fontist",
-    git: "https://github.com/fontist/fontist.git",
-    branch: "revert-safe-install"

--- a/lib/metanorma/compile/render.rb
+++ b/lib/metanorma/compile/render.rb
@@ -58,11 +58,10 @@ module Metanorma
 
     # isodoc is Raw Metanorma XML
     def gather_and_install_fonts(source_file, options, extensions)
-      font_exts = extensions - NO_FONTIST_FORMATS
-      Util.sort_extensions_execution(font_exts).each do |ext|
-        isodoc_options = get_isodoc_options(source_file, options, ext)
-        font_install(isodoc_options.merge(options))
-      end
+      return if (extensions - NO_FONTIST_FORMATS).empty?
+
+      install_options = @processor.extract_options(source_file).merge(options)
+      font_install(install_options)
     end
 
     # Process a single extension (output format)

--- a/spec/collection/collection_spec.rb
+++ b/spec/collection/collection_spec.rb
@@ -668,7 +668,7 @@ RSpec.describe Metanorma::Collection do
       .to include("S-100WG")
   end
 
-  it "extract custom fonts from collection XML for PDF" do
+  it "extract custom fonts from collection XML for PDF", :fontist do
     mock_pdf
     of = File.join(FileUtils.pwd, OUTPATH)
     col = Metanorma::Collection.parse "#{INPATH}/collection-iho.yml"

--- a/spec/collection/collection_spec.rb
+++ b/spec/collection/collection_spec.rb
@@ -685,7 +685,7 @@ RSpec.describe Metanorma::Collection do
       format: %i[pdf presentation xml],
       output_folder: of,
       coverpage: "cover-iho.html",
-      compile: { install_fonts: false },
+      compile: { install_fonts: true, agree_to_terms: true, progress: false },
     )
     expect(renderer)
       .to have_received(:pdfconv)

--- a/spec/compile/compile_spec.rb
+++ b/spec/compile/compile_spec.rb
@@ -19,18 +19,6 @@ RSpec.describe Metanorma::Compile do
     fail "Unexpected exit encountered"
   end
 
-  # Fontist work (install_fonts, location_manifest) is the dominant cost of
-  # most Compile specs and is irrelevant to all but the `context "fontist
-  # integration", :fontist` block below. Stub it out for everything else.
-  before(:each) do |example|
-    next if example.metadata[:fontist]
-
-    allow(Metanorma::Util::FontistHelper)
-      .to receive(:install_fonts).and_return(nil)
-    allow(Metanorma::Util::FontistHelper)
-      .to receive(:location_manifest).and_return(nil)
-  end
-
   it "passes asciidoc options onto isodoc" do
     log = Metanorma::Utils::Log.new
     mock_iso_processor_output(

--- a/spec/compile/compile_spec.rb
+++ b/spec/compile/compile_spec.rb
@@ -139,6 +139,15 @@ RSpec.describe Metanorma::Compile do
   end
 
   context "fontist integration", :fontist do
+  before(:all) do
+    require "metanorma-iso"
+    iso = Metanorma::Registry.instance.find_processor(:iso)
+    Fontist::Manifest.from_hash((iso&.fonts_manifest || {}).dup).install(
+      confirmation: "yes",
+      no_progress: true,
+    )
+  end
+
   it "fontist_install called" do
     mock_pdf
     mock_sts

--- a/spec/compile/compile_spec.rb
+++ b/spec/compile/compile_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Metanorma::Compile do
     fail "Unexpected exit encountered"
   end
 
+  # Fontist work (install_fonts, location_manifest) is the dominant cost of
+  # most Compile specs and is irrelevant to all but the `context "fontist
+  # integration", :fontist` block below. Stub it out for everything else.
+  before(:each) do |example|
+    next if example.metadata[:fontist]
+
+    allow(Metanorma::Util::FontistHelper)
+      .to receive(:install_fonts).and_return(nil)
+    allow(Metanorma::Util::FontistHelper)
+      .to receive(:location_manifest).and_return(nil)
+  end
+
   it "passes asciidoc options onto isodoc" do
     log = Metanorma::Utils::Log.new
     mock_iso_processor_output(
@@ -138,6 +150,7 @@ RSpec.describe Metanorma::Compile do
     expect(xml).to include "International Color Consortium"
   end
 
+  context "fontist integration", :fontist do
   it "fontist_install called" do
     mock_pdf
     mock_sts
@@ -386,6 +399,7 @@ RSpec.describe Metanorma::Compile do
                                                      agree_to_terms: true)
 
     expect(call_order.first).to eq(:install_fonts_safe)
+  end
   end
 
   it "processes metanorma options inside Asciidoc" do

--- a/spec/compile/compile_spec.rb
+++ b/spec/compile/compile_spec.rb
@@ -371,6 +371,23 @@ RSpec.describe Metanorma::Compile do
     compile.compile("spec/assets/custom_fonts.adoc", type: "iso")
   end
 
+  it "installs fonts before performing any location_manifest lookup" do
+    mock_pdf
+    mock_sts
+    compile = Metanorma::Compile.new
+
+    call_order = []
+    allow(Metanorma::Util::FontistHelper)
+      .to receive(:install_fonts_safe) { call_order << :install_fonts_safe }
+    allow(Metanorma::Util::FontistHelper)
+      .to receive(:location_manifest) { call_order << :location_manifest; {} }
+
+    compile.compile("spec/assets/custom_fonts.adoc", type: "iso",
+                                                     agree_to_terms: true)
+
+    expect(call_order.first).to eq(:install_fonts_safe)
+  end
+
   it "processes metanorma options inside Asciidoc" do
     FileUtils.rm_rf "spec/assets/test1.xml"
     FileUtils.rm_rf "spec/assets/test1.doc"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,19 @@ RSpec.configure do |config|
   end
 
   config.include RSpecCommand
+
+  # Fontist's install/location work is the dominant cost of most specs that
+  # exercise Compile or the Collection renderer, and is irrelevant to all
+  # but a few tests that explicitly assert Fontist behaviour. Stub it out
+  # globally; tests that exercise Fontist opt back in via the :fontist tag.
+  config.before(:each) do |example|
+    next if example.metadata[:fontist]
+
+    allow(Metanorma::Util::FontistHelper)
+      .to receive(:install_fonts).and_return(nil)
+    allow(Metanorma::Util::FontistHelper)
+      .to receive(:location_manifest).and_return(nil)
+  end
 end
 
 ASCIIDOC_BLANK_HDR = <<~HDR


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
