### PR TITLE
Fix collection attachment links broken under sectionsplit

### DIFF
--- a/lib/metanorma/collection/renderer/fileprocess.rb
+++ b/lib/metanorma/collection/renderer/fileprocess.rb
@@ -183,21 +183,52 @@ module Metanorma
       def update_bibitem_prep(bib, identifier)
         docid = get_bibitem_docid(bib, identifier) or return [nil, nil]
         newbib = dup_bibitem(docid, bib)
-        url = @files.url(docid, relative: true,
-                                doc: !@files.get(docid, :attachment))
-        # Use :outputs[:html] if available (after compilation),
-        # otherwise convert :out_path to HTML (before compilation)
-        current_html = @files.get(identifier, :outputs)&.dig(:html)
-        if !current_html && (out_path = @files.get(identifier, :out_path))
-          # Convert .xml to .html, following same logic as ref_file_xml2html
-          current_html = if out_path.end_with?(".xml")
-                           out_path.sub(/\.xml$/, ".html")
-                         else
-                           "#{out_path}.html"
-                         end
-        end
+        attachment = @files.get(docid, :attachment)
+        url = @files.url(docid, relative: true, doc: !attachment)
+        current_html = referencing_html_location(identifier, attachment)
         url = make_relative_path(current_html, url) if current_html
         [newbib, url]
+      end
+
+      # Location of the HTML that will carry the cross-reference to the target,
+      # used as the base for relativising the attachment/citation URL.
+      #
+      # Normally this is the referencing document's own output (:outputs[:html]
+      # after compilation, else :out_path converted to .html before it).
+      #
+      # But when the referencing document is sectionsplit, its content is not
+      # emitted at its own out_path: it is split into section files written at
+      # the sectionsplit output location (the collection root, unless a
+      # sectionsplit_filename directory is configured). Relativising an
+      # attachment URL against the unsplit out_path then overshoots -- the
+      # ../../ climbs above the split file and the attachment link breaks
+      # (https://github.com/metanorma/iso-10303/issues/208). So for attachment
+      # targets of a sectionsplit document, base the relative path on the
+      # sectionsplit output directory instead.
+      def referencing_html_location(identifier, attachment)
+        attachment && @files.get(identifier, :sectionsplit) and
+          return sectionsplit_ref_html(identifier)
+        document_ref_html(identifier)
+      end
+
+      # The split section files sit at the sectionsplit output directory: the
+      # collection root, or the directory of a configured sectionsplit_filename.
+      def sectionsplit_ref_html(identifier)
+        d = @files.preserve_directory_structure?(identifier)
+        d ? File.join(File.dirname(d), "x.html") : "x.html"
+      end
+
+      # Use :outputs[:html] if available (after compilation), otherwise convert
+      # :out_path to HTML (before compilation), following ref_file_xml2html.
+      def document_ref_html(identifier)
+        @files.get(identifier, :outputs)&.dig(:html) ||
+          out_path_to_html(@files.get(identifier, :out_path))
+      end
+
+      def out_path_to_html(out_path)
+        out_path or return nil
+        out_path.end_with?(".xml") and return out_path.sub(/\.xml$/, ".html")
+        "#{out_path}.html"
       end
     end
   end

--- a/spec/collection/attachment_link_path_spec.rb
+++ b/spec/collection/attachment_link_path_spec.rb
@@ -1,0 +1,57 @@
+require_relative "../spec_helper"
+
+# Regression for https://github.com/metanorma/iso-10303/issues/208
+#
+# Under sectionsplit, a document's section files are emitted at the sectionsplit
+# output location (the collection root, or the directory of a configured
+# sectionsplit_filename), NOT at the document's own out_path. An attachment /
+# citation URL must therefore be relativised against that split location. If it
+# is relativised against the (unsplit) document out_path instead, the ../../
+# climbs above the split file and the attachment link breaks.
+#
+# referencing_html_location supplies the base path that update_bibitem_prep
+# hands to make_relative_path, so these two together pin the resulting URL.
+RSpec.describe Metanorma::Collection::Renderer do
+  subject(:renderer) { described_class.allocate }
+
+  # out_path is in a subdirectory (as in iso-10303's documents/<part>/...),
+  # which is the only situation where sectionsplit relocation changes the depth.
+  def stub_files(sectionsplit:, preserve: nil, outputs: nil,
+                 out_path: "documents/event/document.xml")
+    attrs = { sectionsplit: sectionsplit, outputs: outputs, out_path: out_path }
+    files = double("FileLookup")
+    allow(files).to receive(:get) { |_id, key| attrs[key] }
+    allow(files).to receive(:preserve_directory_structure?).and_return(preserve)
+    renderer.instance_variable_set(:@files, files)
+  end
+
+  # the attachment URL as resolved onto the referencing document's pages
+  def resolved_url(attachment)
+    base = renderer.send(:referencing_html_location, "doc", attachment)
+    renderer.send(:make_relative_path, base, "plain_schemas/x.exp")
+  end
+
+  describe "#referencing_html_location" do
+    it "relativises an attachment of a sectionsplit document against the " \
+       "collection root (no ../../ overshoot)" do
+      stub_files(sectionsplit: true)
+      expect(resolved_url(true)).to eq "plain_schemas/x.exp"
+    end
+
+    it "relativises against the sectionsplit subdirectory when one is set" do
+      stub_files(sectionsplit: true, preserve: "split/{basename}.html")
+      expect(resolved_url(true)).to eq "../plain_schemas/x.exp"
+    end
+
+    it "uses the document's own out_path when it is not sectionsplit" do
+      stub_files(sectionsplit: false)
+      expect(resolved_url(true)).to eq "../../plain_schemas/x.exp"
+    end
+
+    it "leaves non-attachment targets on the document out_path even under " \
+       "sectionsplit" do
+      stub_files(sectionsplit: true)
+      expect(resolved_url(false)).to eq "../../plain_schemas/x.exp"
+    end
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/208

Fixes broken attachment links (the Annex C "Computer interpretable listings" EXPRESS-schema downloads) under `sectionsplit`. The attachment citation URL was relativised against the referencing document's unsplit `out_path`, so the `../../` overshot once the section files are emitted at the sectionsplit output location (the collection root). Full diagnosis on the issue.

The fix bases the relative path on the sectionsplit output directory when the referencing document is sectionsplit and the target is an attachment; non-attachment targets and non-sectionsplit documents are unchanged.

## Test plan
- New focused regression spec `spec/collection/attachment_link_path_spec.rb` (4 examples: sectionsplit→root-relative, sectionsplit subdirectory, non-sectionsplit unchanged, non-attachment unchanged).
- Existing `collection_sectionsplit_spec.rb` (8) and `collection_spec.rb` / `collection_complex_spec.rb` (40) green; rubocop clean on changed files.
- Verified end-to-end on the iso-10303 `event` document: attachment links resolve under sectionsplit, non-sectionsplit output unchanged, `hidden="true"` preserved.

🤖
