### PR TITLE
fix: inline sectionsplit documents whole into collection PDF/presentation

### DIFF
--- a/lib/metanorma/collection/filelookup/filelookup_sectionsplit.rb
+++ b/lib/metanorma/collection/filelookup/filelookup_sectionsplit.rb
@@ -54,6 +54,14 @@ module Metanorma
         end
         # @files[key].delete(:ids).delete(:anchors)
         @files[key][:indirect_key] = @sectionsplit.key
+        # sectionsplit is HTML-only; hand the parent its whole Presentation XML
+        # so the collection PDF/presentation concatenation inlines the document
+        # intact (raw_file) instead of degrading to a bibdata-only, namespace-
+        # less stub. file_compile early-returns for sectionsplit, so this
+        # :outputs entry is what concatenate1 consumes.
+        # https://github.com/metanorma/iso-10303/issues/208
+        @files[key][:outputs] =
+          { presentation: @sectionsplit.whole_presentation_file }
       end
 
       def add_section_split_cover(manifest, sectionsplit_manifest, ident)

--- a/lib/metanorma/collection/renderer/renderer.rb
+++ b/lib/metanorma/collection/renderer/renderer.rb
@@ -258,10 +258,22 @@ module Metanorma
           .new(key: "documents-inline")
         out.bibdatas.each_key do |ident|
           id = @isodoc.docid_prefix(nil, ident.dup)
-          @files.get(id, :attachment) || @files.get(id, :outputs).nil? and next
+          @files.get(id, :attachment) and next
+          # A non-attachment document with no compiled output for THIS format
+          # cannot be inlined: leaving it in place serialises as a bibdata-only,
+          # namespace-less <metanorma> that mn2pdf silently drops. Skip loudly
+          # rather than crash on a nil path or corrupt the collection PDF.
+          # (Sectionsplit parents get a :presentation output upstream, so they
+          # inline whole for the PDF/presentation path.)
+          outputs = @files.get(id, :outputs)
+          if outputs.nil? || outputs[ext].nil?
+            warn "[metanorma] collection document '#{id}' has no compiled " \
+                 "#{ext} output to inline; skipping (its doc-container would " \
+                 "otherwise be bibdata-only)."
+            next
+          end
           out.documents[Util::key id] =
-            Metanorma::Collection::Document
-              .raw_file(@files.get(id, :outputs)[ext])
+            Metanorma::Collection::Document.raw_file(outputs[ext])
         end
         out
       end

--- a/lib/metanorma/collection/sectionsplit/sectionsplit.rb
+++ b/lib/metanorma/collection/sectionsplit/sectionsplit.rb
@@ -8,7 +8,7 @@ require "concurrent-ruby"
 module Metanorma
   class Collection
     class Sectionsplit
-      attr_accessor :filecache, :key
+      attr_accessor :filecache, :key, :whole_presentation_file
 
       def initialize(opts)
         @input_filename = opts[:input]
@@ -40,6 +40,13 @@ module Metanorma
       # Input XML is Semantic XML
       def sectionsplit
         xml = sectionsplit_prep(File.read(@input_filename), @base, @dir)
+        # Retain the whole (un-split) Presentation XML. sectionsplit is an
+        # HTML-only mechanism, but the collection PDF/presentation path must
+        # inline each document intact; without this the sectionsplit parent
+        # reaches concatenation with no presentation output and degrades to a
+        # bibdata-only, namespace-less <metanorma> stub that mn2pdf drops.
+        # https://github.com/metanorma/iso-10303/issues/208
+        @whole_presentation_file = write_whole_presentation(xml)
         @key = Metanorma::Collection::XrefProcess::xref_preprocess(xml, @isodoc)
         empty = empty_doc(xml)
         empty1 = empty_attachments(empty)
@@ -106,6 +113,16 @@ module Metanorma
         f.close
         r.xpath("//xmlns:svgmap1").each { |x| x.name = "svgmap" }
         r
+      end
+
+      # Persist the whole, svgmap-restored Presentation XML (the in-memory doc,
+      # not the on-disk tmp which still carries the internal svgmap1 marker) so
+      # the collection PDF path can inline the document whole. Written flat to
+      # the split output directory, where the per-section files also live.
+      def write_whole_presentation(xml)
+        fname = File.join(@splitdir, "#{@base}.whole.presentation.xml")
+        File.write(fname, xml.to_xml, encoding: "UTF-8")
+        fname
       end
 
       def sectionsplit_preprocess_semxml(file, filename)

--- a/spec/collection/collection_spec.rb
+++ b/spec/collection/collection_spec.rb
@@ -522,6 +522,37 @@ RSpec.describe Metanorma::Collection do
     FileUtils.rm_rf of
   end
 
+  it "inlines sectionsplit documents whole into the collection presentation " \
+     "XML (iso-10303#208)" do
+    # A sectionsplit document reaching the PDF/presentation concatenation must
+    # be inlined whole. Previously it degraded to a bibdata-only <metanorma> in
+    # the collection namespace (not the standoc namespace), which mn2pdf's
+    # //mn:metanorma XSLT silently drops -- so the collection PDF failed.
+    file = "#{INPATH}/collection_sectionsplit.yml"
+    of = File.join(FileUtils.pwd, OUTPATH)
+    col = Metanorma::Collection.parse file
+    col.render(
+      format: %i[presentation xml html],
+      output_folder: of,
+      coverpage: "collection_cover.html",
+      compile: { install_fonts: false },
+    )
+    pres = Nokogiri::XML(File.read("#{OUTPATH}/collection.presentation.xml"))
+    inner = pres.xpath("//*[local-name()='doc-container']" \
+                       "/*[local-name()='metanorma']")
+    expect(inner).not_to be_empty
+    # every inlined document is in the standoc namespace (not a bibdata-only
+    # stub left in the collection namespace) ...
+    inner.each do |m|
+      expect(m.namespace&.href)
+        .to eq("https://www.metanorma.org/ns/standoc")
+    end
+    # ... and at least the sectionsplit document is inlined with a real body
+    expect(inner.any? { |m| m.at_xpath(".//*[local-name()='sections']") })
+      .to be true
+    FileUtils.rm_rf of
+  end
+
   it "skips indexing of files in coverpage on request" do
     file = "#{INPATH}/collection.dup.yml"
     of = File.join(FileUtils.pwd, OUTPATH)


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/208

A collection with `sectionsplit: true` and a PDF/presentation format built a broken `collection.presentation.xml`: each sectionsplit document's inner `<metanorma>` was a bibdata-only stub in the collection namespace (not the standoc namespace), which mn2pdf's `//mn:metanorma` XSLT silently drops — so the collection PDF built with no document body and no XSL-FO.

`sectionsplit` is an HTML-only mechanism; for the PDF/presentation path a document must be inlined **whole**. The section-split already compiles the un-split document to a Presentation XML (`Sectionsplit#sectionsplit_prep`), so this retains that (svgmap-restored) whole presentation and hands it to the parent as `:outputs[:presentation]`; `concatenate1` then inlines it via `raw_file`, restoring both the body and the standoc namespace. `file_compile`'s sectionsplit early-return is untouched, so there is **no double compile**.

`concatenate1` is also hardened to skip-with-warning any document that has no compiled output for the format being concatenated, instead of silently emitting a bibdata-only stub or crashing on a nil path.

Full diagnosis and verification are in the ticket.

## Test plan

- [x] New high-level spec: renders a `sectionsplit` collection to presentation (no mn2pdf) and asserts every inlined `<metanorma>` is standoc-namespaced with a real body.
- [x] `spec/collection/collection_sectionsplit_spec.rb` — 8/8.
- [x] Full `spec/collection/` — 53 examples, 0 failures.
- [ ] Real-world: rebuild the SMRL collection PDF against this branch (metanorma/iso-10303#208).

🤖
