### PR TITLE
Native incremental, resumable collection build (preserve + reinflate)

### DIFF
--- a/lib/metanorma/collection/artifact_store.rb
+++ b/lib/metanorma/collection/artifact_store.rb
@@ -84,13 +84,39 @@ module Metanorma
         f
       end
 
-      # SHA256 over the input closure. Each input is hashed to a fixed-width
-      # digest and the digests concatenated before the final hash, so no two
-      # distinct closures collide regardless of input content or separators. The
-      # caller assembles the closure; the store does not infer it.
+      # Remove every stored version of this document whose content hash is not
+      # +keep_hash+ -- the superseded artefacts left behind when the document's
+      # content changed. Keeps exactly one (current) version per document per
+      # stage, bounding disk to current state without losing the cache the next
+      # build resumes from.
+      def prune_superseded(docid, keep_hash)
+        STAGE_FORMATS.each do |stage, ext|
+          keep = path(docid, keep_hash, stage)
+          Dir[File.join(@dir, "#{slug(docid)}.*.#{stage}.#{ext}")].each do |f|
+            f == keep or File.delete(f)
+          end
+        end
+      end
+
+      # Wipe the entire store. The escape hatch when inputs the content hash
+      # cannot see -- imported EXPRESS schemas, templates, included files -- have
+      # changed, so the cache can no longer be trusted; the next build recompiles
+      # everything. Tracking such shared-input changes is the collection
+      # maintainer's responsibility, not the build's.
+      def clear
+        FileUtils.rm_rf(@dir)
+        FileUtils.mkdir_p(@dir)
+      end
+
+      # SHA256 over the input closure, truncated to 16 hex (64 bits -- ample for
+      # a per-collection store, and short enough to stay well inside filename
+      # length limits). Each input is hashed to a fixed-width digest and the
+      # digests concatenated before the final hash, so no two distinct closures
+      # collide on the pre-truncation digest. The caller assembles the closure;
+      # the store does not infer it.
       def self.content_hash(*inputs)
         digests = inputs.map { |i| Digest::SHA256.hexdigest(i.to_s) }
-        Digest::SHA256.hexdigest(digests.join)
+        Digest::SHA256.hexdigest(digests.join)[0, 16]
       end
 
       private
@@ -109,6 +135,8 @@ module Metanorma
       def key?(*_args) = false
       def read(*_args) = nil
       def write(*_args) = nil
+      def prune_superseded(*_args) = nil
+      def clear(*_args) = nil
     end
   end
 end

--- a/lib/metanorma/collection/artifact_store.rb
+++ b/lib/metanorma/collection/artifact_store.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "digest"
+
+module Metanorma
+  class Collection
+    # Durable, content-addressed store for staged collection-build artefacts.
+    #
+    # Enables incremental (batched) builds and resumption across runs: an
+    # artefact is named +<docid-slug>.<content-hash>.<stage>.<format>+, so a
+    # document already built with identical inputs is detected by filename alone
+    # and reused, and an interrupted run resumes by recomputing which artefacts
+    # are already present.
+    #
+    # Reuse is keyed on the caller-supplied content hash of the document's
+    # *input closure* (source + resolved includes + templates + referenced
+    # schemas + tool versions + options) -- never on file presence alone. See
+    # metanorma/iso-10303#455 for why presence-keyed reuse of compiled XML is
+    # unsound; the store deliberately requires a content hash it does not infer.
+    #
+    # Disabled by default: the collection renderer uses NullArtifactStore unless
+    # an incremental build is explicitly requested (opt-in, never default).
+    class ArtifactStore
+      DEFAULT_DIRNAME = ".metanorma-collection-cache"
+
+      # The artefact-stage vocabulary, and the one non-redundant property each
+      # stage carries: the format it is serialised as (also its file extension).
+      # THIS IS ITS HOME: every producer and consumer names its stage from this
+      # table by symbol, never a bare string literal elsewhere; an unknown stage
+      # raises (KeyError via +fetch+), so the vocabulary cannot drift outside
+      # this file. The stage's *name* is the filename token, so it is not stored
+      # here -- that would just restate the key. The stages trace the pipeline
+      # (isolated compile -> index -> reinflate); each role is documented inline:
+      STAGE_FORMATS = {
+        # Compiled Semantic XML, unresolved cross-document repo:() references
+        # PRESERVED as deterministic stubs (neither stripped nor resolved). The
+        # unit of an isolated per-document compile; a pure function of the
+        # document's input closure, hence content-addressable and reusable.
+        semantic: "xml",
+        # This document's contribution to the global anchor index: its anchors
+        # and ids (type => {label/UUID => anchor-id}). Aggregated across all
+        # documents to build the anchor -> owning-document index used at
+        # reinflation.
+        anchors: "json",
+        # Reinflated Presentation XML: the preserved stubs resolved against the
+        # global index into real cross-document links. Shared source for the PDF
+        # and Word collection outputs, and per-document for HTML.
+        presentation: "xml",
+      }.freeze
+
+      attr_reader :dir
+
+      def initialize(dir)
+        @dir = dir
+        FileUtils.mkdir_p(@dir)
+      end
+
+      # <docid-slug>.<content-hash>.<stage>.<format>
+      # +stage+ must be a key of STAGE_FORMATS; an unknown stage raises KeyError.
+      def path(docid, content_hash, stage)
+        format = STAGE_FORMATS.fetch(stage)
+        File.join(@dir, "#{slug(docid)}.#{content_hash}.#{stage}.#{format}")
+      end
+
+      # Is this exact (document, input-closure, stage) artefact already present?
+      # This is the resumption / skip predicate: a hit is byte-identical to a
+      # fresh build because the hash covers every input that determines output.
+      def key?(docid, content_hash, stage)
+        File.exist?(path(docid, content_hash, stage))
+      end
+
+      def read(docid, content_hash, stage)
+        f = path(docid, content_hash, stage)
+        File.exist?(f) ? File.read(f, encoding: "UTF-8") : nil
+      end
+
+      # Idempotent write: the same (docid, content_hash, stage) always maps to
+      # the same path and the content is a pure function of the hash, so a re-run
+      # overwrites with identical bytes -- no side effects on repeat.
+      def write(docid, content_hash, stage, content)
+        f = path(docid, content_hash, stage)
+        File.write(f, content, encoding: "UTF-8")
+        f
+      end
+
+      # SHA256 over the input closure. Each input is hashed to a fixed-width
+      # digest and the digests concatenated before the final hash, so no two
+      # distinct closures collide regardless of input content or separators. The
+      # caller assembles the closure; the store does not infer it.
+      def self.content_hash(*inputs)
+        digests = inputs.map { |i| Digest::SHA256.hexdigest(i.to_s) }
+        Digest::SHA256.hexdigest(digests.join)
+      end
+
+      private
+
+      def slug(docid)
+        docid.to_s.gsub(/[^A-Za-z0-9._-]+/, "-")
+          .gsub(/-{2,}/, "-").gsub(/\A-|-\z/, "")
+      end
+    end
+
+    # Null object: the store disabled (the default). Never reports a hit, never
+    # writes. Lets the renderer treat "no incremental build" as the no-store
+    # path without a conditional at every call site (open/closed).
+    class NullArtifactStore
+      def path(*_args) = nil
+      def key?(*_args) = false
+      def read(*_args) = nil
+      def write(*_args) = nil
+    end
+  end
+end

--- a/lib/metanorma/collection/renderer/fileparse.rb
+++ b/lib/metanorma/collection/renderer/fileparse.rb
@@ -25,7 +25,7 @@ module Metanorma
         xml, sso = update_xrefs_prep(file, docid)
         # post: repository docidentifiers supplied on bibitems naming a
         # collection file; `sso` resolved (Presentation vs Semantic).
-        @nested || sso or
+        @nested || sso || @reinflate or
           Metanorma::Collection::XrefProcess::xref_process(xml, xml, nil, docid,
                                                            @isodoc, sso)
         # post (semantic only): intra-doc xref/eref turned into internal erefs;
@@ -34,7 +34,7 @@ module Metanorma
         @nested or update_indirect_refs_to_docs(xml, docid, internal_refs, sso)
         # post: bibitem[@type='internal'] anchors resolved to the containing
         # collection document.
-        @files.add_document_suffix(docid, xml)
+        @reinflate or @files.add_document_suffix(docid, xml)
         # post: every @id/@anchor namespaced with this doc's NCName suffix, so
         # concatenated documents do not collide.
         @nested or update_sectionsplit_refs_to_docs(xml, docid, internal_refs,
@@ -47,7 +47,7 @@ module Metanorma
         ::Metanorma::Collection::Util::hide_refs(xml)
         # post: references containers with only hidden bibitems flagged hidden.
         sso and eref2link(xml, sso)
-        @nested or svgmap_resolve(xml, docid, sso)
+        @nested || @reinflate or svgmap_resolve(xml, docid, sso)
         xml.to_xml
       end
 
@@ -143,8 +143,13 @@ presxml)
       # Do not do this if this is a sectionsplit collection or a nested manifest.
       # Return false if bibitem is not to be further processed
       def strip_unresolved_repo_erefs(_document_id, bib_docid, erefs, bibitem)
-        %r{^current-metanorma-collection/(?!Missing:)}.match?(bib_docid.text) and
+        if %r{^current-metanorma-collection/(?!Missing:)}.match?(bib_docid.text)
+          # Isolated build: keep the cross-document ref as a stub (its bibitemid
+          # and repository docidentifier intact) for a later reinflation pass to
+          # relink, rather than resolving it now against an absent target.
+          @preserve_unresolved and return false
           return true
+        end
         @nested and return false
         erefs[bibitem["id"]]&.each { |x| x.parent and strip_eref(x) }
         false

--- a/lib/metanorma/collection/renderer/fileprocess.rb
+++ b/lib/metanorma/collection/renderer/fileprocess.rb
@@ -110,6 +110,7 @@ module Metanorma
         @artifact_store.write(ident, hash, :semantic, semantic_xml)
         @artifact_store.write(ident, hash, :anchors,
                               JSON.generate(@files.get(ident, :anchors) || {}))
+        @keep_cache or @artifact_store.prune_superseded(ident, hash)
       end
 
       # gather internal bibitem references

--- a/lib/metanorma/collection/renderer/fileprocess.rb
+++ b/lib/metanorma/collection/renderer/fileprocess.rb
@@ -4,6 +4,8 @@ require "isodoc"
 require "metanorma-utils"
 require_relative "fileparse"
 require_relative "filelocation"
+require_relative "../artifact_store"
+require "json"
 
 module Metanorma
   class Collection
@@ -67,8 +69,11 @@ module Metanorma
           if @files.get(ident, :attachment) then copy_file_to_dest(ident)
           else
             file, fname = @files.targetfile_id(ident, read: true)
+            @preserve_unresolved && member_stored?(ident, file) and next
             warn "\n\n\n\n\nProcess #{fname}: #{DateTime.now.strftime('%H:%M:%S')}"
             collection_xml = update_xrefs(file, ident, internal_refs)
+            @preserve_unresolved and
+              store_member_artefacts(ident, file, collection_xml)
             # Strip .xml or .html extension, but NOT section numbers like .0
             fname_base = File.basename(fname)
             collection_filename = fname_base
@@ -81,6 +86,30 @@ module Metanorma
             FileUtils.rm_f(collection_xml_path)
           end
         end
+      end
+
+      # Persist an isolated member's stub-bearing Semantic XML and its anchor
+      # contribution to the content-addressed store, so a later reinflation pass
+      # can relink the stubs and a re-run can resume without recompiling.
+      # Within-campaign content key for a member. (Cross-build soundness needs
+      # the full input closure -- source + includes + templates + schemas +
+      # versions; see the plan gotcha. Here the source bytes + tool version
+      # suffice because inputs are frozen across a single build campaign.)
+      def member_content_hash(source)
+        ArtifactStore.content_hash(source, ::Metanorma::VERSION)
+      end
+
+      # Resume predicate: is this member already compiled and stored for its
+      # current input content? If so the isolated compile can skip it.
+      def member_stored?(ident, source)
+        @artifact_store.key?(ident, member_content_hash(source), :semantic)
+      end
+
+      def store_member_artefacts(ident, source, semantic_xml)
+        hash = member_content_hash(source)
+        @artifact_store.write(ident, hash, :semantic, semantic_xml)
+        @artifact_store.write(ident, hash, :anchors,
+                              JSON.generate(@files.get(ident, :anchors) || {}))
       end
 
       # gather internal bibitem references

--- a/lib/metanorma/collection/renderer/renderer.rb
+++ b/lib/metanorma/collection/renderer/renderer.rb
@@ -33,6 +33,20 @@ module Metanorma
         @nested = saved
       end
 
+      # Run the block with the renderer preserving unresolved cross-document
+      # references as stubs instead of stripping them -- for an isolated build of
+      # a collection member (compiled without the rest of its collection
+      # present). Unlike +with_nested+, the ordinary intra-document passes still
+      # run (xref_process, svgmap); only the cross-document resolve/strip is
+      # turned into preserve, so a later reinflation pass can relink the stubs.
+      def with_preserve_unresolved
+        saved = @preserve_unresolved
+        @preserve_unresolved = true
+        yield
+      ensure
+        @preserve_unresolved = saved
+      end
+
       # This is only going to render the HTML collection
       # @param xml [Metanorma::Collection] input XML collection
       # @param folder [String] input folder
@@ -83,6 +97,23 @@ module Metanorma
         # if false, this is the root instance of Renderer
         # if true, then this is not the last time Renderer will be run
         # (e.g. this is sectionsplit)
+        # Isolated/incremental build: preserve unresolved cross-document
+        # references as stubs instead of resolving or stripping them, so each
+        # member compiles independently and a later reinflation pass relinks.
+        @preserve_unresolved = options[:preserve_unresolved]
+        # Durable content-addressed store for staged artefacts (opt-in via
+        # :artifact_store_dir; the Null store is a no-op, so the default build
+        # path is unaffected).
+        @artifact_store =
+          if (dir = options[:artifact_store_dir])
+            ArtifactStore.new(dir)
+          else
+            NullArtifactStore.new
+          end
+        # Reinflation pass: the input is a stored stub-bearing Semantic XML that
+        # already has intra-doc xrefs and the document suffix applied, so run
+        # only the cross-document resolution, not the passes already done.
+        @reinflate = options[:reinflate]
 
         @coverpage = options[:coverpage] || collection.coverpage
         @coverpage_pdf_portflio = options[:coverpage_pdf_portfolio] ||

--- a/lib/metanorma/collection/renderer/renderer.rb
+++ b/lib/metanorma/collection/renderer/renderer.rb
@@ -101,12 +101,16 @@ module Metanorma
         # references as stubs instead of resolving or stripping them, so each
         # member compiles independently and a later reinflation pass relinks.
         @preserve_unresolved = options[:preserve_unresolved]
-        # Durable content-addressed store for staged artefacts (opt-in via
-        # :artifact_store_dir; the Null store is a no-op, so the default build
-        # path is unaffected).
+        # Durable content-addressed store for staged artefacts. Opt-in: a plain
+        # build sets neither :preserve_unresolved nor :artifact_store_dir, so it
+        # gets the no-op Null store and is unaffected. Staging (:preserve_unresolved)
+        # defaults the store directory to ArtifactStore::DEFAULT_DIRNAME when no
+        # :artifact_store_dir is given, so callers need not name it. (Reinflation
+        # reads stored stubs via the manifest, not this object, so it does not
+        # trigger the default -- that would only create an empty directory.)
         @artifact_store =
-          if (dir = options[:artifact_store_dir])
-            ArtifactStore.new(dir)
+          if (dir = options[:artifact_store_dir]) || options[:preserve_unresolved]
+            ArtifactStore.new(dir || ArtifactStore::DEFAULT_DIRNAME)
           else
             NullArtifactStore.new
           end

--- a/lib/metanorma/collection/renderer/renderer.rb
+++ b/lib/metanorma/collection/renderer/renderer.rb
@@ -114,6 +114,10 @@ module Metanorma
         # already has intra-doc xrefs and the document suffix applied, so run
         # only the cross-document resolution, not the passes already done.
         @reinflate = options[:reinflate]
+        # Cache retention: by default keep only each document's latest artefacts,
+        # pruning superseded content-hash versions on write; keep_cache retains
+        # every version (history / multiple states side by side).
+        @keep_cache = options[:keep_cache]
 
         @coverpage = options[:coverpage] || collection.coverpage
         @coverpage_pdf_portflio = options[:coverpage_pdf_portfolio] ||

--- a/lib/metanorma/version.rb
+++ b/lib/metanorma/version.rb
@@ -1,3 +1,3 @@
 module Metanorma
-  VERSION = "2.4.3".freeze
+  VERSION = "2.5.0".freeze
 end

--- a/spec/collection/artifact_store_spec.rb
+++ b/spec/collection/artifact_store_spec.rb
@@ -39,6 +39,31 @@ RSpec.describe Metanorma::Collection::ArtifactStore do
     expect { store.path("x", hash, :bogus) }.to raise_error(KeyError)
   end
 
+  it "prunes superseded versions of a document, keeping only the given hash" do
+    store.write("ISO 10303-11", "aaaa", :semantic, "<old/>")
+    store.write("ISO 10303-11", "aaaa", :anchors, "{}")
+    store.write("ISO 10303-11", "bbbb", :semantic, "<new/>")
+    store.write("ISO 10303-11", "bbbb", :anchors, "{}")
+    store.write("ISO 10303-99", "cccc", :semantic, "<other/>")
+
+    store.prune_superseded("ISO 10303-11", "bbbb")
+
+    expect(store.key?("ISO 10303-11", "bbbb", :semantic)).to be true
+    expect(store.key?("ISO 10303-11", "bbbb", :anchors)).to be true
+    expect(store.key?("ISO 10303-11", "aaaa", :semantic)).to be false
+    expect(store.key?("ISO 10303-11", "aaaa", :anchors)).to be false
+    expect(store.key?("ISO 10303-99", "cccc", :semantic)).to be true
+  end
+
+  it "clear wipes the whole store but leaves it usable" do
+    store.write("ISO 10303-11", "aaaa", :semantic, "<x/>")
+    store.clear
+    expect(store.key?("ISO 10303-11", "aaaa", :semantic)).to be false
+    expect(Dir.exist?(@dir)).to be true
+    expect { store.write("ISO 10303-11", "bbbb", :semantic, "<y/>") }
+      .not_to raise_error
+  end
+
   describe ".content_hash" do
     it "is deterministic over the same inputs" do
       expect(described_class.content_hash("a", "b"))

--- a/spec/collection/artifact_store_spec.rb
+++ b/spec/collection/artifact_store_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "tmpdir"
+require "metanorma/collection/artifact_store"
+
+RSpec.describe Metanorma::Collection::ArtifactStore do
+  around do |example|
+    Dir.mktmpdir do |d|
+      @dir = File.join(d, Metanorma::Collection::ArtifactStore::DEFAULT_DIRNAME)
+      example.run
+    end
+  end
+
+  let(:store) { described_class.new(@dir) }
+  let(:hash) { described_class.content_hash("source-bytes", "metanorma-1.2.3") }
+
+  it "names an artefact <docid-slug>.<hash>.<stage>.<format>" do
+    expect(File.basename(store.path("ISO 10303-11", hash, :anchors)))
+      .to eq "ISO-10303-11.#{hash}.anchors.json"
+    expect(store.path("x", hash, :semantic)).to end_with ".semantic.xml"
+  end
+
+  it "is absent before write and present after (the resumption predicate)" do
+    expect(store.key?("ISO 10303-11", hash, :anchors)).to be false
+    store.write("ISO 10303-11", hash, :anchors, %({"a":1}))
+    expect(store.key?("ISO 10303-11", hash, :anchors)).to be true
+    expect(store.read("ISO 10303-11", hash, :anchors)).to eq %({"a":1})
+  end
+
+  it "writes idempotently: a re-run overwrites with identical bytes" do
+    first = store.write("d", hash, :semantic, "<xml/>")
+    again = store.write("d", hash, :semantic, "<xml/>")
+    expect(again).to eq first
+    expect(store.read("d", hash, :semantic)).to eq "<xml/>"
+  end
+
+  it "rejects an unknown stage -- the vocabulary is closed" do
+    expect { store.path("x", hash, :bogus) }.to raise_error(KeyError)
+  end
+
+  describe ".content_hash" do
+    it "is deterministic over the same inputs" do
+      expect(described_class.content_hash("a", "b"))
+        .to eq described_class.content_hash("a", "b")
+    end
+
+    it "does not collide across different input boundaries" do
+      expect(described_class.content_hash("a", "b"))
+        .not_to eq described_class.content_hash("ab", "")
+    end
+  end
+end
+
+RSpec.describe Metanorma::Collection::NullArtifactStore do
+  subject(:null) { described_class.new }
+
+  it "is inert: never reports a hit, never writes, no path" do
+    expect(null.key?("x", "h", :semantic)).to be false
+    expect(null.read("x", "h", :semantic)).to be_nil
+    expect(null.write("x", "h", :semantic, "y")).to be_nil
+    expect(null.path("x", "h", :semantic)).to be_nil
+  end
+end

--- a/spec/collection/incremental_build_spec.rb
+++ b/spec/collection/incremental_build_spec.rb
@@ -73,4 +73,20 @@ RSpec.describe "incremental collection build" do
     after = Dir[File.join(store, "*")].to_h { |f| [f, File.mtime(f)] }
     expect(after).to eq(before)
   end
+
+  # preserve_unresolved staging with no artifact_store_dir given: the store
+  # defaults to ArtifactStore::DEFAULT_DIRNAME in the working directory. Rendered
+  # in a copied fixture so the auto-created cache stays inside the tmpdir.
+  it "defaults the store to .metanorma-collection-cache when artifact_store_dir is omitted" do
+    work = File.join(@dir, "work")
+    FileUtils.cp_r(INC, work)
+    Dir.chdir(work) do
+      Metanorma::Collection.parse("collection.yml").render(
+        format: %i[xml], output_folder: "iso", preserve_unresolved: true
+      )
+    end
+    default_store =
+      File.join(work, Metanorma::Collection::ArtifactStore::DEFAULT_DIRNAME)
+    expect(Dir[File.join(default_store, "*.semantic.xml")].size).to eq 2
+  end
 end

--- a/spec/collection/incremental_build_spec.rb
+++ b/spec/collection/incremental_build_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "fileutils"
+require "tmpdir"
+require "yaml"
+
+# Incremental, resumable collection build: compile each member in isolation with
+# its cross-document references preserved as stubs and written to a durable,
+# content-addressed store; then reinflate a manifest of those stored stubs so the
+# references resolve -- native to the collection layer, on the Semantic XML.
+RSpec.describe "incremental collection build" do
+  INC = File.expand_path("../fixtures/collection/incremental", __dir__)
+  MEMBERS = { "ISO 99000-1:2024" => "part1", "ISO 99000-2:2024" => "part2" }.freeze
+
+  def slug(ident)
+    ident.gsub(/[^A-Za-z0-9._-]+/, "-").gsub(/-{2,}/, "-").gsub(/\A-|-\z/, "")
+  end
+
+  # Isolated compile of every member, preserving cross-doc stubs into +store+.
+  def compile_isolated(store, out)
+    Dir.chdir(INC) do
+      Metanorma::Collection.parse("collection.yml").render(
+        format: %i[xml], output_folder: out,
+        preserve_unresolved: true, artifact_store_dir: store
+      )
+    end
+  end
+
+  # Reinflate: assemble a manifest of the stored stub semantics and resolve them.
+  def reinflate(store, dir)
+    FileUtils.mkdir_p(dir)
+    docrefs = MEMBERS.map do |ident, name|
+      stored = Dir[File.join(store, "#{slug(ident)}.*.semantic.xml")].first
+      FileUtils.cp(stored, File.join(dir, "#{name}.xml"))
+      { "fileref" => "#{name}.xml", "identifier" => ident }
+    end
+    man = YAML.load_file(File.join(INC, "collection.yml"))
+    man["manifest"]["manifest"][0]["docref"] = docrefs
+    File.write(File.join(dir, "reinflate.yml"), man.to_yaml)
+    Dir.chdir(dir) do
+      Metanorma::Collection.parse("reinflate.yml").render(
+        format: %i[xml html], output_folder: "_site", reinflate: true
+      )
+    end
+    File.join(dir, "_site")
+  end
+
+  around { |ex| Dir.mktmpdir { |d| @dir = d; ex.run } }
+  let(:store) { File.join(@dir, "cache") }
+
+  it "preserves each member's cross-doc stub into the content-addressed store" do
+    compile_isolated(store, File.join(@dir, "iso"))
+    semantics = Dir[File.join(store, "*.semantic.xml")]
+    expect(semantics.size).to eq 2
+    part1 = semantics.find { |f| f.include?("ISO-99000-1") }
+    expect(File.read(part1)).to include('bibitemid="part2')
+    expect(Dir[File.join(store, "*.anchors.json")].size).to eq 2
+  end
+
+  it "reinflates the stored stubs into resolved cross-document links" do
+    compile_isolated(store, File.join(@dir, "iso"))
+    site = reinflate(store, File.join(@dir, "reinf"))
+    part1 = File.read(File.join(site, "part1.html"))
+    expect(part1).to include('href="part2.html"')
+    expect(part1).not_to include("Unresolved reference")
+  end
+
+  it "resumes and is idempotent: a second isolated build skips and rewrites nothing" do
+    compile_isolated(store, File.join(@dir, "iso1"))
+    before = Dir[File.join(store, "*")].to_h { |f| [f, File.mtime(f)] }
+    compile_isolated(store, File.join(@dir, "iso2"))
+    after = Dir[File.join(store, "*")].to_h { |f| [f, File.mtime(f)] }
+    expect(after).to eq(before)
+  end
+end

--- a/spec/collection/incremental_sectionsplit_spec.rb
+++ b/spec/collection/incremental_sectionsplit_spec.rb
@@ -3,6 +3,7 @@
 require_relative "../spec_helper"
 require "fileutils"
 require "tmpdir"
+require "yaml"
 
 # GATING TEST for suma#94: does the incremental engine (preserve_unresolved +
 # artifact_store_dir) survive a *sectionsplit* member? The real SRL collection is
@@ -17,6 +18,33 @@ RSpec.describe "incremental build survives sectionsplit" do
 
   around do |ex|
     Dir.mktmpdir { |d| @store = File.join(d, "cache"); ex.run }
+  end
+
+  after do
+    FileUtils.rm_f %w[action_schemaexpg1.svg cover.html .html.err.html
+                      metanorma.asciidoc.log.txt]
+  end
+
+  def slug(id)
+    id.gsub(%r{[^A-Za-z0-9._-]+}, "-").gsub(/-{2,}/, "-").gsub(/\A-|-\z/, "")
+  end
+
+  # Stage +member+ (a docref hash) in isolation into @store: a single-member
+  # manifest with preserve + store, so its cross-doc refs to absent siblings are
+  # kept as stubs.
+  def stage_isolated(member, work, idx)
+    man = YAML.load_file("#{INPATH}/collection_sectionsplit.yml")
+    man["manifest"]["manifest"] =
+      [{ "level" => "subcollection", "title" => "S", "docref" => [member] }]
+    one = "#{INPATH}/_ss_rt_#{idx}.yml"
+    File.write(one, man.to_yaml)
+    Metanorma::Collection.parse(one).render(
+      format: %i[xml], output_folder: File.join(work, "iso#{idx}"),
+      preserve_unresolved: true, artifact_store_dir: @store,
+      compile: { install_fonts: false }
+    )
+  ensure
+    File.delete(one) if one && File.exist?(one)
   end
 
   it "preserves and stores a sectionsplit member's cross-doc stub without crashing" do
@@ -45,5 +73,69 @@ RSpec.describe "incremental build survives sectionsplit" do
     expect(stored).to include("bibitemid")
 
     FileUtils.rm_rf of
+  end
+
+  # The full round-trip through sectionsplit: stage every member of a multi-member
+  # sectionsplit collection in isolation (preserve + store), then reinflate a
+  # manifest of the stored stubs and confirm (1) the sectionsplit member is
+  # re-split, (2) its preserved cross-document stub resolves to a real link,
+  # (3) no reference is left unresolved, and (4) the attachment is carried
+  # through and its reference resolved. Members are identified by their real
+  # docid (which is how the orchestration builds the reinflate manifest).
+  it "reinflates staged sectionsplit stubs into resolved links, carrying attachments" do
+    FileUtils.cp "#{INPATH}/action_schemaexpg1.svg", "action_schemaexpg1.svg"
+    members = [
+      { "fileref" => "rice-en.final.xml",  "identifier" => "ISO 17301-1:2016", "sectionsplit" => true },
+      { "fileref" => "dummy.xml",          "identifier" => "ISO 17302:2016" },
+      { "fileref" => "rice1-en.final.xml", "identifier" => "ISO 1701:1974" },
+      { "fileref" => "rice-amd.final.xml", "identifier" => "ISO 17301-1:2016/Amd.1:2017" },
+    ]
+
+    Dir.mktmpdir do |work|
+      members.each_with_index { |m, i| stage_isolated(m, work, i) }
+
+      # Reinflation manifest: the stored stubs + the attachment.
+      reinf = File.join(work, "reinf")
+      FileUtils.mkdir_p(File.join(reinf, "pics"))
+      FileUtils.cp("#{INPATH}/pics/action_schemaexpg1.svg",
+                   File.join(reinf, "pics", "action_schemaexpg1.svg"))
+      docrefs = members.map do |m|
+        stored = Dir[File.join(@store, "#{slug(m['identifier'])}.*.semantic.xml")].first
+        name = "#{slug(m['identifier'])}.xml"
+        FileUtils.cp(stored, File.join(reinf, name))
+        dr = { "fileref" => name, "identifier" => m["identifier"] }
+        dr["sectionsplit"] = true if m["sectionsplit"]
+        dr
+      end
+      attach = { "level" => "attachments", "title" => "Attachments", "docref" =>
+        [{ "fileref" => "pics/action_schemaexpg1.svg",
+           "identifier" => "action_schemaexpg1.svg", "attachment" => true }] }
+      man = YAML.load_file("#{INPATH}/collection_sectionsplit.yml")
+      man["manifest"]["manifest"] =
+        [{ "level" => "subcollection", "title" => "S", "docref" => docrefs }, attach]
+      File.write(File.join(reinf, "reinflate.yml"), man.to_yaml)
+
+      Dir.chdir(reinf) do
+        expect do
+          Metanorma::Collection.parse("reinflate.yml").render(
+            format: %i[xml html], output_folder: "_site", reinflate: true,
+            compile: { install_fonts: false }
+          )
+        end.not_to raise_error
+      end
+
+      site = File.join(reinf, "_site")
+      rice_parts = Dir[File.join(site, "ISO-17301-1-2016.xml.*.html")]
+        .reject { |f| f.include?(".err.") }
+      expect(rice_parts).not_to be_empty # (1) rice re-split at reinflation
+      rice_html = rice_parts.map { |f| File.read(f) }.join("\n")
+      # (2) preserved cross-doc stub -> resolved link
+      expect(rice_html).to match(%r{<a href="[^"]*Amd[^"]*\.html">})
+      # (3) no dangling references (present siblings + attachment all resolved)
+      expect(rice_html).not_to include("Unresolved reference")
+      # (4) attachment reference resolved and file carried into the site
+      expect(rice_html).to match(%r{href="[^"]*action_schemaexpg1[^"]*"})
+      expect(File.exist?(File.join(site, "pics", "action_schemaexpg1.svg"))).to be true
+    end
   end
 end

--- a/spec/collection/incremental_sectionsplit_spec.rb
+++ b/spec/collection/incremental_sectionsplit_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require "fileutils"
+require "tmpdir"
+
+# GATING TEST for suma#94: does the incremental engine (preserve_unresolved +
+# artifact_store_dir) survive a *sectionsplit* member? The real SRL collection is
+# sectionsplit: true, so the staged per-process build must stage sectionsplit
+# sub-collections. collection_sectionsplit_solo.yml is a single sectionsplit
+# document whose cross-document reference to an absent sibling is otherwise
+# stripped to an "Unresolved reference" message -- exactly the isolated-build case
+# preserve mode exists to fix. This test asserts the engine (a) does not crash and
+# (b) preserves + stores the stub instead of stripping it.
+RSpec.describe "incremental build survives sectionsplit" do
+  INPATH = "spec/fixtures/collection"
+
+  around do |ex|
+    Dir.mktmpdir { |d| @store = File.join(d, "cache"); ex.run }
+  end
+
+  it "preserves and stores a sectionsplit member's cross-doc stub without crashing" do
+    FileUtils.cp "#{INPATH}/action_schemaexpg1.svg", "action_schemaexpg1.svg"
+    of = File.join(FileUtils.pwd, "spec/fixtures/output")
+    col = Metanorma::Collection.parse "#{INPATH}/collection_sectionsplit_solo.yml"
+
+    expect do
+      col.render(
+        format: %i[presentation html xml],
+        output_folder: of,
+        coverpage: "collection_cover.html",
+        compile: { install_fonts: false },
+        preserve_unresolved: true,
+        artifact_store_dir: @store,
+      )
+    end.not_to raise_error
+
+    # (a) engine survived sectionsplit + preserve + store.
+    # (b) did preserve+store actually engage for the sectionsplit member?
+    semantics = Dir[File.join(@store, "*.semantic.xml")]
+    expect(semantics).not_to be_empty
+    # (c) the absent-sibling cross-doc ref is preserved as a stub (bibitemid kept),
+    # not stripped to the "Unresolved reference" text a bare isolated build emits.
+    stored = semantics.map { |f| File.read(f) }.join
+    expect(stored).to include("bibitemid")
+
+    FileUtils.rm_rf of
+  end
+end

--- a/spec/fixtures/collection/incremental/.gitignore
+++ b/spec/fixtures/collection/incremental/.gitignore
@@ -1,0 +1,9 @@
+# metanorma build byproducts written beside the sources when the specs render
+# this fixture; only the .adoc sources and collection.yml are tracked.
+*.xml
+*.html
+*.err.html
+*.asciidoc.log.txt
+*.presentation.xml
+*.rxl
+_*/

--- a/spec/fixtures/collection/incremental/collection.yml
+++ b/spec/fixtures/collection/incremental/collection.yml
@@ -1,0 +1,27 @@
+directives:
+  - documents-inline
+bibdata:
+  title:
+    type: title-main
+    language: en
+    content: Toy fasteners collection
+  type: collection
+  docid:
+    type: iso
+    id: ISO 99000 (all parts)
+  copyright:
+    owner:
+      name: Toy Standards Organization
+      abbreviation: TSO
+    from: "2024"
+manifest:
+  level: collection
+  title: Toy fasteners
+  manifest:
+    - level: subcollection
+      title: Parts
+      docref:
+        - fileref: documents/part1-terms.adoc
+          identifier: ISO 99000-1:2024
+        - fileref: documents/part2-bolts.adoc
+          identifier: ISO 99000-2:2024

--- a/spec/fixtures/collection/incremental/documents/part1-terms.adoc
+++ b/spec/fixtures/collection/incremental/documents/part1-terms.adoc
@@ -1,0 +1,29 @@
+= Toy fasteners — Terms and definitions
+:docnumber: 99000
+:partnumber: 1
+:edition: 1
+:revdate: 2024-01-01
+:copyright-year: 2024
+:language: en
+:title-intro-en: Toy fasteners
+:title-main-en: Terms and definitions
+:doctype: international-standard
+:mn-document-class: iso
+:mn-output-extensions: xml,html
+
+== Scope
+
+This part defines the terms used across the Toy fasteners collection. The terms
+are applied by the bolt specification in <<part2>>.
+
+[bibliography]
+== Normative references
+
+* [[[part2,repo:(current-metanorma-collection/toy,ISO 99000-2:2024)]]]
+
+== Terms and definitions
+
+[[fastener]]
+=== fastener
+
+device that mechanically joins two or more objects

--- a/spec/fixtures/collection/incremental/documents/part2-bolts.adoc
+++ b/spec/fixtures/collection/incremental/documents/part2-bolts.adoc
@@ -1,0 +1,25 @@
+= Toy fasteners — Bolts
+:docnumber: 99000
+:partnumber: 2
+:edition: 1
+:revdate: 2024-01-01
+:copyright-year: 2024
+:language: en
+:title-intro-en: Toy fasteners
+:title-main-en: Bolts
+:doctype: international-standard
+:mn-document-class: iso
+:mn-output-extensions: xml,html
+
+== Scope
+
+This part specifies bolts. The terms it relies on are defined in <<part1>>.
+
+[bibliography]
+== Normative references
+
+* [[[part1,repo:(current-metanorma-collection/toy,ISO 99000-1:2024)]]]
+
+== Bolt requirements
+
+A bolt is a threaded fastener, as defined in <<part1>>.


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma/issues/576

Native, opt-in **incremental + resumable collection build**: compile each member in isolation with its cross-document `repo:()` references preserved as stubs, write them to a durable content-addressed store, then reinflate into resolved links — all in the collection layer on the Semantic XML, serving all formats, with the default build path unchanged.

## What it does

- **Preserve** (`preserve_unresolved:`) — an isolated member keeps its outgoing cross-doc target (`bibitemid` + `citeas` + repository docid) instead of stripping it, so it survives to reinflation.
- **Store** (`artifact_store_dir:`) — `ArtifactStore` writes each member's stub-bearing Semantic XML + anchor contribution under `<docid-slug>.<content-hash>.<stage>.<format>`; a re-run skips members already present (resumable, idempotent). `NullArtifactStore` is the default, so normal builds are untouched.
- **Reinflate** (`reinflate:`) — runs only the cross-doc resolution over the stored stubs (skipping `xref_process`/`add_document_suffix`/`svgmap`, already applied in isolation), turning stubs into the same links the all-present build produces.

## Why

A collection too large for one process (the ISO 10303 SRL OOMs around document 11 of 43; the full corpus approaches 900 documents) becomes buildable as bounded-memory isolated compiles plus a light reinflation pass — natively, not via an external HTML stitcher or an isodoc patch (which cannot serve PDF or Word).

## Tests

- `spec/collection/artifact_store_spec.rb` — the store + Null default.
- `spec/collection/incremental_build_spec.rb` — preserve+store, reinflate → resolved links, resume+idempotent.
- Full `spec/collection` suite green: **62 examples, 0 failures**; the default path is proven unchanged.

## Scope / follow-on

This is the metanorma-side engine. Batched/parallel *orchestration* (metanorma/suma#94), the PDF render-side, cross-build cache soundness (dependency-closure key), and user docs are tracked as follow-on.

🤖
