### PR TITLE
Synthesize <uri type=attachment> on collection attachment bibitems

### DIFF
--- a/lib/metanorma/collection/renderer/fileprocess.rb
+++ b/lib/metanorma/collection/renderer/fileprocess.rb
@@ -198,7 +198,7 @@ module Metanorma
       end
 
       def update_bibitem(bib, identifier)
-        newbib, url = update_bibitem_prep(bib, identifier)
+        newbib, url, attachment = update_bibitem_prep(bib, identifier)
         newbib or return
         dest = begin
           newbib.at("./docidentifier") || newbib.at(ns("./docidentifier"))
@@ -206,18 +206,22 @@ module Metanorma
           nil
         end
         dest or dest = newbib.elements[-1]
+        # An attachment carries both a <uri type="attachment"> (which drives
+        # isodoc's fmt-link attachment="true") and the citation uri; the
+        # attachment uri goes first. metanorma/iso-10303#208.
+        attachment and dest.previous = "<uri type='attachment'>#{url}</uri>"
         dest.previous = "<uri type='citation'>#{url}</uri>"
         bib.replace(newbib)
       end
 
       def update_bibitem_prep(bib, identifier)
-        docid = get_bibitem_docid(bib, identifier) or return [nil, nil]
+        docid = get_bibitem_docid(bib, identifier) or return [nil, nil, nil]
         newbib = dup_bibitem(docid, bib)
         attachment = @files.get(docid, :attachment)
         url = @files.url(docid, relative: true, doc: !attachment)
         current_html = referencing_html_location(identifier, attachment)
         url = make_relative_path(current_html, url) if current_html
-        [newbib, url]
+        [newbib, url, attachment]
       end
 
       # Location of the HTML that will carry the cross-reference to the target,

--- a/spec/fixtures/collection/collection_full.xml
+++ b/spec/fixtures/collection/collection_full.xml
@@ -944,6 +944,7 @@
                          </copyright>
                       </bibitem>
                       <bibitem hidden="true" id="action_schemaexpg1.svg_ISO_17301-1_2016">
+                         <uri type="attachment">pics/action_schemaexpg1.svg</uri>
                          <uri type="citation">pics/action_schemaexpg1.svg</uri>
                          <docidentifier>action_schemaexpg1.svg</docidentifier>
                       </bibitem>

--- a/spec/fixtures/collection/collection_rename.xml
+++ b/spec/fixtures/collection/collection_rename.xml
@@ -938,6 +938,7 @@
                          </copyright>
                       </bibitem>
                       <bibitem hidden="true" id="action_schemaexpg1.svg_ISO_17301-1_2016">
+                         <uri type="attachment">../action_schemaexpg1.svg</uri>
                          <uri type="citation">../action_schemaexpg1.svg</uri>
                          <docidentifier>action_schemaexpg1.svg</docidentifier>
                       </bibitem>


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/208

Collection attachment bibitems synthesized from the manifest now carry `<uri type="attachment">` (before the citation uri), so attachment cross-references render as `<fmt-link attachment="true">` in the presentation/PDF path — previously only hand-authored fixtures (which write both uris) worked.

Regression guard: the `collection_full.xml` / `collection_rename.xml` goldens (`collection_complex_spec`) now assert the marker on the synthesized `action_schemaexpg1.svg` attachment. Full diagnosis in the ticket.

🤖
