### PR TITLE
surface collection member rendering failures instead of exiting 0

### DIFF
--- a/lib/metanorma/collection/collection.rb
+++ b/lib/metanorma/collection/collection.rb
@@ -11,6 +11,9 @@ module Metanorma
 
   class AdocFileNotFoundException < StandardError; end
 
+  # One or more collection members failed to render (#586)
+  class RenderFailureException < StandardError; end
+
   # Metanorma collection of documents
   class Collection
     attr_reader :file, :prefatory, :final
@@ -132,8 +135,24 @@ module Metanorma
       opts[:log] = @log
       opts[:flavor] = @flavor
       output_folder(opts)
-      ::Metanorma::Collection::Renderer.render self, opts
+      cr = ::Metanorma::Collection::Renderer.render self, opts
       clean_exit
+      render_failures_abort(cr)
+      cr
+    end
+
+    # A member whose rendering fails no longer lets the collection
+    # report success with the document missing from the output (#586).
+    # Every member is rendered before aborting, so one run reports all
+    # failures; the raise makes callers (CLI, suma) exit non-zero. Runs
+    # after clean_exit so the failures are in the written log.
+    def render_failures_abort(renderer)
+      f = renderer.fatal_errors
+      f.empty? and return
+      raise RenderFailureException.new(
+        "Collection render failed for #{f.size} document(s):\n" +
+        f.join("\n"),
+      )
     end
 
     def output_folder(opts)

--- a/lib/metanorma/collection/log.rb
+++ b/lib/metanorma/collection/log.rb
@@ -11,6 +11,13 @@ module Metanorma
       "METANORMA_3": { category: "Cross-References",
                        error: "<strong>** Unresolved reference to document %s from eref</strong>",
                        severity: 2 },
+      "METANORMA_4": { category: "Rendering",
+                       error: "Collection member %s: expected output " \
+                              "file not generated: %s",
+                       severity: 0 },
+      "METANORMA_5": { category: "Rendering",
+                       error: "Collection member %s: rendering error: %s",
+                       severity: 0 },
     }.freeze
     # rubocop:enable Naming/VariableNumber
   end

--- a/lib/metanorma/collection/renderer/filelocation.rb
+++ b/lib/metanorma/collection/renderer/filelocation.rb
@@ -26,12 +26,16 @@ module Metanorma
         end
       end
 
-      # Move file to new output filename if specified
+      # Move file to new output filename if specified. A member that
+      # failed to render has nothing to move: keep the original name
+      # registered so output verification reports it as missing, rather
+      # than crashing the whole collection on the mv (#586).
       def handle_new_output_filename(output_fname, new_output_fname)
         return output_fname unless new_output_fname
 
-        FileUtils.mv(File.join(@outdir, output_fname),
-                     File.join(@outdir, new_output_fname))
+        src = File.join(@outdir, output_fname)
+        File.exist?(src) or return output_fname
+        FileUtils.mv(src, File.join(@outdir, new_output_fname))
         new_output_fname
       end
 

--- a/lib/metanorma/collection/renderer/fileprocess.rb
+++ b/lib/metanorma/collection/renderer/fileprocess.rb
@@ -18,9 +18,54 @@ module Metanorma
         opts = compile_options_base(identifier)
           .merge(compile_options_update(identifier))
 
+        err_count = @compile.errors.size
         @compile.compile file, opts
         @files.set(identifier, :outputs, {})
         file_compile_formats(filename, identifier, opts)
+        file_compile_verify(identifier, @compile.errors[err_count..] || [])
+      end
+
+      # A member whose rendering raised produces no output file, but the
+      # collection build used to continue, exit 0, and link the absent
+      # document from index.html -- silent data loss (#586). Two
+      # complementary checks close that hole. (1) Compile pools rescued
+      # error messages in @compile.errors for its caller to surface; the
+      # standalone CLI does, but the collection pipeline never read the
+      # pool. The pool is shared across members and never reset, so the
+      # slice appended during this member's compile is this member's
+      # errors -- sound while members compile sequentially (the current
+      # design; @compile's own format-level parallelism is joined before
+      # compile returns). (2) Independently of whether anything was
+      # pooled, verify the outputs registered for the member exist on
+      # disk. Failures are reported here and accumulated; the collection
+      # renders every remaining member before Collection#render aborts,
+      # so one run reports all failed members.
+      def file_compile_verify(identifier, errors)
+        missing = (@files.get(identifier, :outputs) || {})
+          .reject { |_fmt, path| File.exist?(path) }
+        errors.empty? && missing.empty? and return
+        file_compile_failure_log(identifier, errors, missing)
+        msg = file_compile_failure_msg(identifier, errors, missing)
+        ::Metanorma::Util.log("[metanorma] Error: #{msg}", :error)
+        fatal_errors << msg
+      end
+
+      def file_compile_failure_log(identifier, errors, missing)
+        missing.each_value do |path|
+          @log&.add("METANORMA_4", nil, params: [identifier, path])
+        end
+        errors.each do |e|
+          @log&.add("METANORMA_5", nil, params: [identifier, e])
+        end
+      end
+
+      def file_compile_failure_msg(identifier, errors, missing)
+        ret = []
+        missing.empty? or
+          ret << "expected output not generated: " \
+                 "#{missing.values.join(', ')}"
+        ret += errors
+        "Failed to render collection member #{identifier}: #{ret.join('; ')}"
       end
 
       def compile_options_base(identifier)

--- a/lib/metanorma/collection/renderer/renderer.rb
+++ b/lib/metanorma/collection/renderer/renderer.rb
@@ -19,7 +19,7 @@ module Metanorma
 
       attr_accessor :isodoc, :isodoc_presxml
       attr_reader :xml, :compile, :compile_options, :documents, :outdir,
-                  :manifest
+                  :manifest, :fatal_errors
 
       # Run the block with the renderer in nested mode, restoring the previous
       # mode afterwards. Nested mode (used by sectionsplit, which re-enters this
@@ -93,6 +93,10 @@ module Metanorma
         @final = collection.final
         @c = HTMLEntities.new
         @files_to_delete = []
+        # Per-member rendering failures (missing outputs, pooled compile
+        # errors), accumulated by file_compile_verify; Collection#render
+        # aborts on them once every member has rendered (#586).
+        @fatal_errors = []
         @nested = options[:nested]
         # if false, this is the root instance of Renderer
         # if true, then this is not the last time Renderer will be run
@@ -302,7 +306,10 @@ module Metanorma
           # (Sectionsplit parents get a :presentation output upstream, so they
           # inline whole for the PDF/presentation path.)
           outputs = @files.get(id, :outputs)
-          if outputs.nil? || outputs[ext].nil?
+          # The registered path may exist without the file: a member whose
+          # rendering failed registers its intended outputs but writes
+          # nothing (#586), so check the disk, not just the registration.
+          if outputs.nil? || outputs[ext].nil? || !File.exist?(outputs[ext])
             warn "[metanorma] collection document '#{id}' has no compiled " \
                  "#{ext} output to inline; skipping (its doc-container would " \
                  "otherwise be bibdata-only)."

--- a/lib/metanorma/compile/render.rb
+++ b/lib/metanorma/compile/render.rb
@@ -135,8 +135,7 @@ module Metanorma
                         output_paths[:out], ext, isodoc_options)
       wrap_html(options, output_paths[:ext], output_paths[:out])
     rescue StandardError => e
-      strict = ext == :presentation || isodoc_options[:strict] == true
-      isodoc_error_process(e, strict, false)
+      isodoc_error_process(e, strict_error?(ext, isodoc_options), false)
     end
 
     # Process format directly from semantic XML
@@ -145,8 +144,7 @@ module Metanorma
                         ext, isodoc_options)
       true # Return as Thread equivalent
     rescue StandardError => e
-      strict = ext == :presentation || isodoc_options[:strict] == "true"
-      isodoc_error_process(e, strict, true)
+      isodoc_error_process(e, strict_error?(ext, isodoc_options), true)
       ext != :presentation
     end
 
@@ -168,12 +166,29 @@ module Metanorma
 
     private
 
+    # A presentation failure is always strict: every downstream format
+    # needs the presentation XML. The :strict option arrives as a
+    # boolean from the CLI but as a string from document attributes, so
+    # accept both (the two rescue sites previously each checked only
+    # one form).
+    def strict_error?(ext, isodoc_options)
+      ext == :presentation ||
+        [true, "true"].include?(isodoc_options[:strict])
+    end
+
+    # On the strict path the message is pooled into @errors for the
+    # caller to surface (the standalone CLI reports the pool and
+    # aborts; the collection renderer attributes it to the failed
+    # member, #586). The class+message line is also printed here in all
+    # cases, so it sits adjacent to its backtrace in the build log: a
+    # pooled message surfaces only at end of run, and a bare backtrace
+    # mid-log is undiagnosable. The exception class is retained because
+    # for errors like Encoding::UndefinedConversionError it carries
+    # half the diagnosis.
     def isodoc_error_process(err, strict, must_abort)
-      if strict || err.message.include?("Fatal:")
-        @errors << err.message
-      else
-        puts err.message
-      end
+      msg = "#{err.class}: #{err.message}"
+      strict || err.message.include?("Fatal:") and @errors << msg
+      puts msg
       puts err.backtrace.join("\n")
       must_abort and 1
     end

--- a/spec/collection/collection_spec.rb
+++ b/spec/collection/collection_spec.rb
@@ -522,6 +522,51 @@ RSpec.describe Metanorma::Collection do
     FileUtils.rm_rf of
   end
 
+  it "renders all members, then aborts naming members whose rendering " \
+     "failed (#586)" do
+    # A member whose compile produces no outputs (e.g. presentation
+    # rendering raised) must not let the collection exit 0 with the
+    # document silently missing from the output. The collection renders
+    # every remaining member first, then Collection#render raises,
+    # attributing the pooled compile errors to the failed member.
+    file = "#{INPATH}/collection.dup.yml"
+    of = File.join(FileUtils.pwd, OUTPATH)
+    col = Metanorma::Collection.parse file
+    allow_any_instance_of(Metanorma::Compile).to receive(:compile)
+      .and_wrap_original do |m, f, opts|
+      if /dummy\.1/.match?(f)
+        m.receiver.errors <<
+          "Encoding::UndefinedConversionError: \"\\xFF\" to UTF-8"
+        nil
+      else
+        m.call(f, opts)
+      end
+    end
+    err = nil
+    begin
+      col.render(
+        format: %i[presentation xml html],
+        output_folder: of,
+        coverpage: "collection_cover.html",
+        compile: { install_fonts: false },
+      )
+    rescue Metanorma::RenderFailureException => e
+      err = e
+    end
+    expect(err).not_to be_nil
+    expect(err.message).to include("ISO 44002")
+    expect(err.message).to include("expected output not generated")
+    expect(err.message)
+      .to include("Encoding::UndefinedConversionError: \"\\xFF\" to UTF-8")
+    expect(err.message).not_to include("ISO 44001")
+    expect(err.message).not_to include("ISO 44003")
+    # the failure did not stop the remaining members from rendering
+    expect(File.exist?("#{OUTPATH}/dummy.html")).to be true
+    expect(File.exist?("#{OUTPATH}/dummy.2.html")).to be true
+    expect(File.exist?("#{OUTPATH}/dummy.1.html")).to be false
+    FileUtils.rm_rf of
+  end
+
   it "inlines sectionsplit documents whole into the collection presentation " \
      "XML (iso-10303#208)" do
     # A sectionsplit document reaching the PDF/presentation concatenation must

--- a/spec/compile/compile_spec.rb
+++ b/spec/compile/compile_spec.rb
@@ -726,7 +726,7 @@ RSpec.describe Metanorma::Compile do
     c = Metanorma::Compile.new
     c.compile("spec/assets/test2.adoc", type: "iso", extension_keys: [:pdf])
 
-    expect(c.errors).to include(exception_msg)
+    expect(c.errors).to include("RuntimeError: #{exception_msg}")
   end
 
   it "don't skip Presentation XML errors" do
@@ -736,8 +736,8 @@ RSpec.describe Metanorma::Compile do
     c = Metanorma::Compile.new
     c.compile("spec/assets/test2.adoc", type: "iso", extension_keys: [:html],
                                         strict: true)
-    expect(c.errors).not_to include("Anything")
-    expect(c.errors).to include("Something")
+    expect(c.errors).not_to include("RuntimeError: Anything")
+    expect(c.errors).to include("RuntimeError: Something")
 
     allow_any_instance_of(IsoDoc::Iso::PresentationXMLConvert)
       .to receive(:convert)
@@ -745,8 +745,9 @@ RSpec.describe Metanorma::Compile do
     c = Metanorma::Compile.new
     c.compile("spec/assets/test2.adoc", type: "iso", extension_keys: [:html],
                                         strict: true)
-    expect(c.errors).to include("Anything")
-    expect(c.errors).not_to include("Something") # never runs HTML
+    expect(c.errors).to include("RuntimeError: Anything")
+    # never runs HTML
+    expect(c.errors).not_to include("RuntimeError: Something")
   end
 
   it "use threads number from METANORMA_PARALLEL" do
@@ -1176,6 +1177,31 @@ RSpec.describe Metanorma::Compile do
         :presentation,
         hash,
       ).at_least :once
+  end
+
+  context "isodoc_error_process (#586)" do
+    it "prints exception class and message adjacent to the backtrace, " \
+       "and pools class and message on the strict path" do
+      c = Metanorma::Compile.new
+      err = Encoding::UndefinedConversionError.new("from ASCII-8BIT to UTF-8")
+      err.set_backtrace(["lib/somewhere.rb:1:in 'decode'"])
+      expect { c.send(:isodoc_error_process, err, true, false) }
+        .to output(
+          %r{UndefinedConversionError: from ASCII-8BIT to UTF-8\nlib/somewhere},
+        ).to_stdout
+      expect(c.errors)
+        .to include("Encoding::UndefinedConversionError: " \
+                    "from ASCII-8BIT to UTF-8")
+    end
+
+    it "prints but does not pool on the non-strict path" do
+      c = Metanorma::Compile.new
+      err = RuntimeError.new("non-fatal problem")
+      err.set_backtrace(["lib/somewhere.rb:1"])
+      expect { c.send(:isodoc_error_process, err, false, false) }
+        .to output(/RuntimeError: non-fatal problem/).to_stdout
+      expect(c.errors).to be_empty
+    end
   end
 
   # Mock process_input_adoc_hdr to add :sectionsplit: true attribute


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma/issues/586

Diagnosis and design rationale in the ticket. Documentation of the new METANORMA_4/METANORMA_5 fatal errors is on metanorma.org batch branch `20260615` (cabafc86).

🤖
