### PR TITLE
Taste-aware output-format selection (thread supplied_type to output)

### DIFF
--- a/lib/metanorma/compile/compile_options.rb
+++ b/lib/metanorma/compile/compile_options.rb
@@ -62,10 +62,39 @@ module Metanorma
                                              options_in_file[:sourcecode])
       end
 
+      # Document-model transformer specs contributed by the active taste
+      # (+options[:supplied_type]+), or +{}+. Lets a taste (e.g. OIML) make its
+      # own output format selectable and choose its presentation/semantic leg,
+      # via the taste-aware metanorma-core Processor (metanorma-core#12).
+      def taste_transformers(options)
+        taste = options[:supplied_type]
+        return {} unless taste && defined?(Metanorma::TasteRegister) &&
+          Metanorma::TasteRegister.respond_to?(:document_transformers_for)
+
+        Metanorma::TasteRegister.document_transformers_for(taste) || {}
+      end
+
+      # The processor's output formats merged with the suffixes of any
+      # taste-contributed document-model formats, so those formats pass
+      # extension validation and get an output suffix.
+      def effective_output_formats(options)
+        @processor.output_formats.merge(
+          taste_transformers(options)
+            .transform_values { |spec| spec[:suffix] }.compact,
+        )
+      end
+
+      # Whether +ext+ is generated from presentation XML, honouring both the
+      # processor's own answer and a taste transformer's +:presentation+ flag.
+      def uses_presentation_xml?(ext, options)
+        @processor.use_presentation_xml(ext) ||
+          (taste_transformers(options)[ext] || {})[:presentation] == true
+      end
+
       def get_extensions(options)
         ext = extract_extensions(options)
         !ext.include?(:presentation) && ext.any? do |e|
-          @processor.use_presentation_xml(e)
+          uses_presentation_xml?(e, options)
         end and ext << :presentation
         !ext.include?(:rxl) && options[:site_generate] and
           ext << :rxl
@@ -73,10 +102,11 @@ module Metanorma
       end
 
       def extract_extensions(options)
+        formats = effective_output_formats(options)
         options[:extension_keys] ||=
-          @processor.output_formats.reduce([]) { |memo, (k, _)| memo << k }
+          formats.reduce([]) { |memo, (k, _)| memo << k }
         options[:extension_keys].reduce([]) do |memo, e|
-          if @processor.output_formats[e] then memo << e
+          if formats[e] then memo << e
           else
             unsupported_format_error(e)
             memo
@@ -123,6 +153,9 @@ module Metanorma
       def copy_isodoc_options_attrs(options, ret)
         ret[:datauriimage] = true if options[:datauriimage]
         ret[:sourcefilename] = options[:filename]
+        # Carry the active taste through to Processor#output, so its taste-aware
+        # document_transformers resolve there (metanorma-core#12).
+        ret[:supplied_type] = options[:supplied_type]
         %i(bare sectionsplit sectionsplit_filename install_fonts baseassetpath
            aligncrosselements tocfigures toctables tocrecommendations tocexamples
            strict fonts)

--- a/lib/metanorma/compile/render.rb
+++ b/lib/metanorma/compile/render.rb
@@ -67,7 +67,7 @@ module Metanorma
     # Process a single extension (output format)
     def process_ext(ext, source_file, semantic_xml, bibdata, output_paths,
                     options)
-      output_paths[:ext] = @processor.output_formats[ext]
+      output_paths[:ext] = effective_output_formats(options)[ext]
       output_paths[:out] = @output_filename.for_format(ext) ||
         output_paths[:xml].sub(/\.[^.]+$/, ".#{output_paths[:ext]}")
       isodoc_options = get_isodoc_options(source_file, options, ext)
@@ -78,7 +78,7 @@ module Metanorma
       )
 
       # Otherwise, determine if it uses presentation XML
-      if @processor.use_presentation_xml(ext)
+      if uses_presentation_xml?(ext, options)
         # Format requires presentation XML first, then convert to final format
         process_via_presentation_xml(ext, output_paths, options, isodoc_options)
       else

--- a/spec/metanorma/compile/taste_output_selection_spec.rb
+++ b/spec/metanorma/compile/taste_output_selection_spec.rb
@@ -20,18 +20,25 @@ RSpec.describe "Metanorma::Compile taste-aware output selection" do
     end
   end
 
-  let(:register) { Metanorma::TasteRegister.instance }
-
+  # Stand-in for the per-taste hook metanorma-taste provides once released
+  # (metanorma-taste#188): define the class method the compile helpers call, so
+  # this spec is self-contained and passes on the released taste gem too.
   around do |example|
-    hooks = register.instance_variable_get(:@transformer_hooks)&.dup
-    specs = register.instance_variable_get(:@transformer_specs)&.dup
-    register.register_document_transformers(:widget) do
+    klass = Metanorma::TasteRegister.singleton_class
+    had = Metanorma::TasteRegister.respond_to?(:document_transformers_for)
+    orig = klass.instance_method(:document_transformers_for) if had
+    klass.send(:define_method, :document_transformers_for) do |taste|
+      next {} unless taste.to_sym == :widget
+
       { widgetsts: { suffix: "widget.sts.xml", presentation: true } }
     end
     example.run
   ensure
-    register.instance_variable_set(:@transformer_hooks, hooks)
-    register.instance_variable_set(:@transformer_specs, specs)
+    if had
+      klass.send(:define_method, :document_transformers_for, orig)
+    else
+      klass.send(:remove_method, :document_transformers_for)
+    end
   end
 
   it "merges a taste's format suffix into the effective output formats" do
@@ -45,12 +52,15 @@ RSpec.describe "Metanorma::Compile taste-aware output selection" do
   end
 
   it "offers no taste format when no taste is active" do
-    expect(compile.send(:effective_output_formats, {})).not_to have_key(:widgetsts)
+    expect(compile.send(:effective_output_formats, {}))
+      .not_to have_key(:widgetsts)
   end
 
   it "picks the presentation leg from the taste spec's :presentation flag" do
-    expect(compile.send(:uses_presentation_xml?, :widgetsts, supplied_type: :widget))
-      .to be(true)
+    leg = compile.send(
+      :uses_presentation_xml?, :widgetsts, supplied_type: :widget
+    )
+    expect(leg).to be(true)
   end
 
   it "carries :supplied_type into isodoc options" do

--- a/spec/metanorma/compile/taste_output_selection_spec.rb
+++ b/spec/metanorma/compile/taste_output_selection_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+# Taste-aware output selection in the compile driver (metanorma-core#12): a
+# taste-declared document-model format (e.g. the OIML taste's :oimlsts) becomes
+# selectable, gets its suffix, and picks its presentation/semantic leg, and the
+# active taste is carried into isodoc options for the taste-aware Processor.
+RSpec.describe "Metanorma::Compile taste-aware output selection" do
+  # Real stand-in processor (no mocking library): only the two methods the
+  # helpers call.
+  let(:processor) do
+    Class.new do
+      def output_formats = { html: "html", xml: "xml" }
+      def use_presentation_xml(ext) = ext == :html
+    end.new
+  end
+
+  let(:compile) do
+    Metanorma::Compile.allocate.tap do |c|
+      c.instance_variable_set(:@processor, processor)
+    end
+  end
+
+  let(:register) { Metanorma::TasteRegister.instance }
+
+  around do |example|
+    hooks = register.instance_variable_get(:@transformer_hooks)&.dup
+    specs = register.instance_variable_get(:@transformer_specs)&.dup
+    register.register_document_transformers(:widget) do
+      { widgetsts: { suffix: "widget.sts.xml", presentation: true } }
+    end
+    example.run
+  ensure
+    register.instance_variable_set(:@transformer_hooks, hooks)
+    register.instance_variable_set(:@transformer_specs, specs)
+  end
+
+  it "merges a taste's format suffix into the effective output formats" do
+    fmts = compile.send(:effective_output_formats, supplied_type: :widget)
+    expect(fmts[:widgetsts]).to eq("widget.sts.xml")
+  end
+
+  it "keeps the processor's own formats" do
+    fmts = compile.send(:effective_output_formats, supplied_type: :widget)
+    expect(fmts[:html]).to eq("html")
+  end
+
+  it "offers no taste format when no taste is active" do
+    expect(compile.send(:effective_output_formats, {})).not_to have_key(:widgetsts)
+  end
+
+  it "picks the presentation leg from the taste spec's :presentation flag" do
+    expect(compile.send(:uses_presentation_xml?, :widgetsts, supplied_type: :widget))
+      .to be(true)
+  end
+
+  it "carries :supplied_type into isodoc options" do
+    ret = {}
+    compile.send(:copy_isodoc_options_attrs, { supplied_type: :widget }, ret)
+    expect(ret[:supplied_type]).to eq(:widget)
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-core/issues/12

## Summary

Lets a taste-declared document-model output format (e.g. the OIML taste's
`:oimlsts`) be selected and rendered by the compile driver.

- Carry `options[:supplied_type]` into `isodoc_options`
  (`copy_isodoc_options_attrs`), so the taste-aware metanorma-core `Processor`
  resolves the taste's `document_transformers` at `#output` time.
- `effective_output_formats` merges taste-format suffixes into the processor's
  formats (extension validation + suffix); `uses_presentation_xml?` honours a
  taste spec's `:presentation` flag. `extract_extensions` / `get_extensions` /
  render `process_ext` route through them.
- **Guarded and backward-compatible** — no taste, or a taste without the hook,
  behaves exactly as before. Merges on released deps.

## Test plan

New `compile/taste_output_selection_spec.rb` **5/0** (real stand-in processor +
registered fake taste, no mocking library).

🤖
