### PR TITLE
Materialise absolute pdf-portfolio directive paths into the output folder

### DIFF
--- a/lib/metanorma/collection/renderer/renderer.rb
+++ b/lib/metanorma/collection/renderer/renderer.rb
@@ -161,11 +161,30 @@ module Metanorma
         abs = Pathname.new(val).absolute?
         directives.reject! { |d| d.key == name }
         val = Util::rel_path_resolve(@dirname, val)
-        abs or
-          val = Pathname.new(val).relative_path_from(Pathname.new(@outdir)).to_s
+        val =
+          if abs then directives_host_materialise(val)
+          else Pathname.new(val).relative_path_from(Pathname.new(@outdir)).to_s
+          end
         directives << ::Metanorma::Collection::Config::Directive
           .new(key: name, value: val)
         directives
+      end
+
+      # An absolute directive value can point inside a gem payload (e.g. a
+      # taste's data/ file from Util.taste2coverpage_pdf_portfolio). A
+      # spawned child process that is not this Ruby (mn2pdf/java) may be
+      # unable to read such a path (a packaged virtual filesystem mount,
+      # e.g. tebako on Windows). Copy the file into the output folder —
+      # the child already reads the collection XML from there — and point
+      # the directive at the copy. A missing file keeps its value: the
+      # child reports that as it always has.
+      def directives_host_materialise(val)
+        File.exist?(val) or return val
+        dst = File.expand_path(File.join(@outdir, File.basename(val)))
+        dst == File.expand_path(val) and return val
+        FileUtils.mkdir_p(@outdir)
+        FileUtils.cp(val, dst)
+        dst
       end
 
       def flush_files

--- a/spec/collection/collection_spec.rb
+++ b/spec/collection/collection_spec.rb
@@ -2,6 +2,7 @@
 
 require_relative "../spec_helper"
 require "stringio"
+require "tmpdir"
 
 def capture_stdout
   old = $stdout
@@ -723,6 +724,110 @@ RSpec.describe Metanorma::Collection do
     end
 
     FileUtils.rm_rf of
+  end
+
+  it "materialises an absolute coverpage-pdf-portfolio path into the " \
+     "output folder for child processes that cannot read gem-internal " \
+     "paths" do
+    Dir.mktmpdir do |src|
+      newyaml = "#{INPATH}/collection_abs_portfolio.yml"
+      of = File.join(FileUtils.pwd, OUTPATH)
+      begin
+        pdf = File.join(src, "pdfportfolio_default_page.pdf")
+        File.binwrite(pdf, "%PDF-1.4\nfake portfolio bytes\n")
+        File.write(newyaml,
+                   File.read("#{INPATH}/collection_solo.yml")
+                     .sub("  - documents-inline",
+                          "  - documents-inline\n" \
+                          "  - coverpage-pdf-portfolio: #{pdf}"))
+        col = Metanorma::Collection.parse newyaml
+        col.render(
+          format: %i[presentation xml],
+          output_folder: of,
+          coverpage: "collection_cover.html",
+          compile: { install_fonts: false },
+        )
+        directive = col.directives
+          .find { |d| d.key == "coverpage-pdf-portfolio" }
+        expect(Pathname.new(directive.value).absolute?).to be true
+        expect(File.expand_path(directive.value))
+          .to eq File.expand_path(
+            File.join(of, "pdfportfolio_default_page.pdf")
+          )
+        expect(File.binread(directive.value)).to eq File.binread(pdf)
+        # the presentation XML is what mn2pdf XPath-reads the directive from
+        pres = Nokogiri::XML(
+          File.read("#{OUTPATH}/collection.presentation.xml")
+        )
+        xval = pres.at_xpath("//*[local-name()='directive']" \
+                             "[*[local-name()='key']=" \
+                             "'coverpage-pdf-portfolio']" \
+                             "/*[local-name()='value']")
+        expect(xval&.text).to eq directive.value
+      ensure
+        FileUtils.rm_f newyaml
+        FileUtils.rm_rf of
+      end
+    end
+  end
+
+  it "materialises an absolute keystore-pdf-portfolio path the same way" do
+    Dir.mktmpdir do |src|
+      newyaml = "#{INPATH}/collection_abs_keystore.yml"
+      of = File.join(FileUtils.pwd, OUTPATH)
+      begin
+        ks = File.join(src, "portfolio.p12")
+        File.binwrite(ks, "fake keystore bytes")
+        File.write(newyaml,
+                   File.read("#{INPATH}/collection_solo.yml")
+                     .sub("  - documents-inline",
+                          "  - documents-inline\n" \
+                          "  - keystore-pdf-portfolio: #{ks}"))
+        col = Metanorma::Collection.parse newyaml
+        col.render(
+          format: %i[presentation xml],
+          output_folder: of,
+          coverpage: "collection_cover.html",
+          compile: { install_fonts: false },
+        )
+        directive = col.directives
+          .find { |d| d.key == "keystore-pdf-portfolio" }
+        expect(Pathname.new(directive.value).absolute?).to be true
+        expect(File.expand_path(directive.value))
+          .to eq File.expand_path(File.join(of, "portfolio.p12"))
+        expect(File.binread(directive.value)).to eq File.binread(ks)
+      ensure
+        FileUtils.rm_f newyaml
+        FileUtils.rm_rf of
+      end
+    end
+  end
+
+  it "keeps a relative coverpage-pdf-portfolio relative to the output " \
+     "folder without copying it" do
+    newyaml = "#{INPATH}/collection_rel_portfolio.yml"
+    of = File.join(FileUtils.pwd, OUTPATH)
+    begin
+      File.write(newyaml,
+                 File.read("#{INPATH}/collection_solo.yml")
+                   .sub("  - documents-inline",
+                        "  - documents-inline\n" \
+                        "  - coverpage-pdf-portfolio: cover.pdf"))
+      col = Metanorma::Collection.parse newyaml
+      col.render(
+        format: %i[presentation xml],
+        output_folder: of,
+        coverpage: "collection_cover.html",
+        compile: { install_fonts: false },
+      )
+      directive = col.directives
+        .find { |d| d.key == "coverpage-pdf-portfolio" }
+      expect(Pathname.new(directive.value).relative?).to be true
+      expect(File.exist?(File.join(of, "cover.pdf"))).to be false
+    ensure
+      FileUtils.rm_f newyaml
+      FileUtils.rm_rf of
+    end
   end
 
   it "uses local bibdata, preface in prefatory content if needed" do


### PR DESCRIPTION
## Problem

When a collection renders the PDF portfolio (`pdf-portfolio` format), mn2pdf — a separate Java process — reads the `coverpage-pdf-portfolio` / `keystore-pdf-portfolio` directives out of the generated `collection.presentation.xml` and opens those paths itself.

`Util.taste2coverpage_pdf_portfolio` resolves a taste's configured portfolio cover to an **absolute path inside the taste gem** (e.g. `.../gems/metanorma-taste-1.1.0/data/oiml/pdfportfolio_default_page.pdf`). `Renderer#directives_resolve_filepath` kept absolute values untouched, so that gem-internal path was baked verbatim into the presentation XML as content.

On a packaged/virtualised runtime where the gem lives on an in-process virtual filesystem (tebako on Windows), the Java child cannot read that path:

```
[mn2pdf] Fatal error! java.nio.file.NoSuchFileException:
A:\__tfs__\lib\ruby\gems\3.3.0\gems\metanorma-taste-1.1.0\data\oiml\pdfportfolio_default_page.pdf
    at org.metanorma.fop.portfolio.PDFPortfolio.generate(PDFPortfolio.java:95)
```

All per-document PDFs succeed; only the portfolio step fails, and only on Windows.

## Fix

In `directives_resolve_filepath`, an absolute directive value is now **materialised into the output folder**: the file is copied next to `collection.presentation.xml` (a location the child process is already guaranteed to read), and the directive is rewritten to the copy's absolute path.

- Platform-neutral: no runtime detection; the copy is harmless on plain installations.
- Relative values (user-checkout files) keep the existing relative-to-output-folder behaviour; nothing is copied.
- A missing file keeps its original value, so the child reports it exactly as before — no new failure modes at render-init.
- Covers both `coverpage-pdf-portfolio` and `keystore-pdf-portfolio` (same code path).

## Specs

Three new examples in `spec/collection/collection_spec.rb`:

1. absolute `coverpage-pdf-portfolio` → copied into the output folder, directive rewritten, bytes identical, and the value baked into `collection.presentation.xml` matches;
2. absolute `keystore-pdf-portfolio` → same;
3. relative `coverpage-pdf-portfolio` → still relativised against the output folder, no copy (regression pin).
